### PR TITLE
Enable to register upper cases to kana table

### DIFF
--- a/denops/skkeleton/function/input.ts
+++ b/denops/skkeleton/function/input.ts
@@ -81,9 +81,14 @@ export async function kanaInput(context: Context, char: string) {
 
   const lower = char.toLowerCase();
   if (char !== lower) {
-    henkanPoint(context);
-    await kanaInput(context, lower);
-    return;
+    const withShift = `<s-${lower}>`;
+    if (state.table.some((e) => e[0].startsWith(state.feed + withShift))) {
+      char = withShift;
+    } else {
+      henkanPoint(context);
+      await kanaInput(context, lower);
+      return;
+    }
   }
 
   const next = state.feed + char;


### PR DESCRIPTION
`register_kanatable` で大文字アルファベットを使ったマッピングを可能にします。

### モチベーション

AquaSKK では「Q」を押すことで「見出し語入力モード」（≒ `henkanPoint`）に入れます。

https://ja.osdn.net/projects/aquaskk/wiki/keymap.confの文法

しかし現行の `register_kanatable` に以下のように指定しても無視されてしまいます。そのままだと大文字アルファベットは小文字に変換されて `henkanPoint` に渡されるためです。

```vim
call skkeleton#register_kanatable('rom', {'Q': 'henkanPoint'})
```

そこで、`<s-q>` という記述で大文字の「Q」を渡せるようにしてみました。これで AquaSKK と同じ動作が実現できます。


```vim
" Q → henkanPoint
call skkeleton#register_kanatable('rom', {'<s-q>': 'henkanPoint'})
```

複数の文字列を組み合わせても動きます（実用的かどうかはさておき）。

```vim
" HEllo → ほげほげ
call skkeleton#register_kanatable('rom': {'<s-h><s-e>llo': ['ほげほげ', '']})
```

一応やりたいことは実現できたのですが、`register_kanatable` の仕様としてこれで良いのか、などご相談したいです。
