### PR TITLE
fix EnsureString error

### DIFF
--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -92,7 +92,7 @@ async function enable(key?: unknown, vimStatus?: unknown): Promise<string> {
   const context = currentContext.get();
   const state = context.state;
   const denops = context.denops!;
-  if (state.type !== "input" || state.mode !== "direct" && key && vimStatus) {
+  if ((state.type !== "input" || state.mode !== "direct") && key && vimStatus) {
     return handle(key, vimStatus);
   }
   if (await denops.eval("&l:iminsert") !== 1) {
@@ -121,7 +121,7 @@ async function enable(key?: unknown, vimStatus?: unknown): Promise<string> {
 async function disable(key?: unknown, vimStatus?: unknown): Promise<string> {
   const context = currentContext.get();
   const state = currentContext.get().state;
-  if (state.type !== "input" || state.mode !== "direct" && key && vimStatus) {
+  if ((state.type !== "input" || state.mode !== "direct") && key && vimStatus) {
     return handle(key, vimStatus);
   }
   await disableFunc(context);


### PR DESCRIPTION
特定の操作をすると`vimStatus`が定義されていない状態で進行してしまうことがあるようなのですが、そのハンドリングがうまくできておらずエラーが発生することがあったため修正しました。

現在のコードだと、`vimStatus`がundefinedでも動作してしまうようです。

```typescript
console.log(true || false && true && false) // true
```
修正のやり方はマージする際に適宜変えてください。

## 再現手順

一応エラーの再現手順も記載しておきます。
どうしてこの操作でエラーになるのかはよく分かりません…

```
OS: Windows 10
neovim-version: NVIM v0.6.0-dev+356-gbec7f47ce
skkeleton-version: 3fee9c8
```

```vim
" minivimrc
set rtp+=~\.cache\dein\repos\github.com\vim-denops\denops.vim
set rtp+=~\.cache\dein\repos\github.com\kuuote\denops-skkeleton.vim

imap <C-j> <Plug>(skkeleton-enable)
cmap <C-j> <Plug>(skkeleton-enable)
```

1.  `nvim -u minivimrc`
2.  i
3.  Ctrl-j
4.  ESC
5.  :
6.  Ctrl-j
7. エラー

```
Error invoking 'invoke' on channel 4:
Error: Failed to call 'enable' with []: EnsureError: The value must be string
    at ensure (https://deno.land/x/unknownutil@v1.1.4/ensure.ts:36:11)
    at ensureString (https://deno.land/x/unknownutil@v1.1.4/ensure.ts:44:10)
    at handle (file:///C:/Users/ork/.cache/dein/repos/github.com/kuuote/denops-skkeleton.vim/denops/skkeleton/main.ts:166:3)
    at enable (file:///C:/Users/ork/.cache/dein/repos/github.com/kuuote/denops-skkeleton.vim/denops/skkeleton/main.ts:96:12)
    at Session.enable (file:///C:/Users/ork/.cache/dein/repos/github.com/kuuote/denops-skkeleton.vim/denops/skkeleton/main.ts:236:20)
    at async Session.dispatch (https://deno.land/x/msgpack_rpc@v3.1.4/session.ts:99:12)
    at async https://deno.land/x/msgpack_rpc@v3.1.4/session.ts:108:18
    at async Session.handleRequest (https://deno.land/x/msgpack_rpc@v3.1.4/session.ts:104:29)
    at Session.call (https://deno.land/x/msgpack_rpc@v3.1.4/session.ts:207:13)
    at async Service.dispatch (file:///C:/Users/ork/.cache/dein/repos/github.com/vim-denops/denops.vim/denops/@denops-private/service.ts:101:14)
    at async Session.invoke (file:///C:/Users/ork/.cache/dein/repos/github.com/vim-denops/denops.vim/denops/@denops-private/host/nvim.ts:48:16)
    at async Session.dispatch (https://deno.land/x/msgpack_rpc@v3.1.4/session.ts:99:12)
    at async https://deno.land/x/msgpack_rpc@v3.1.4/session.ts:108:18
    at async Session.handleRequest (https://deno.land/x/msgpack_rpc@v3.1.4/session.ts:104:29)
```

