### PR TITLE
Add a stopgap measure to inform mode change

### DIFF
--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -212,8 +212,13 @@ async function handle(key: unknown, vimStatus: unknown): Promise<string> {
       return handled;
     }
   }
+  const before = context.mode;
   await handleKey(context, key);
-  return context.preEdit.output(context.toString());
+  const output = context.preEdit.output(context.toString());
+  if (output === "" && before !== context.mode) {
+    return " \x08";
+  }
+  return output;
 }
 
 export async function main(denops: Denops) {


### PR DESCRIPTION
Fix #43 
Fix https://github.com/delphinus/skkeleton_indicator.nvim/issues/3

`handleKey()` を呼ぶ前後で mode が変わっていたら `''` ではなく <kbd>Space</kbd> + <kbd>Backspace</kbd> を返すことで描画を更新するようにしてみました。一応意図した通りに動いてますがもっと綺麗にできないか……

![Kapture 2021-12-07 at 08 48 04](https://user-images.githubusercontent.com/1239245/144940725-9f93ff54-d2bd-4fa5-84d4-8147d0e74adc.gif)


