### PR TITLE
fix typo in document.

### DIFF
--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -33,7 +33,7 @@ skkeleton-initialize-pre                            *skkeleton-initialize-pre*
         \ "z\<Space>": ["\u3000", ''],
         \ })
     endfunction
-    augroup skkeleton-initlaize-pre
+    augroup skkeleton-initialize-pre
       autocmd!
       autocmd User skkeleton-initialize-pre call s:skkeleton_init()
     augroup END


### PR DESCRIPTION
augroupの部分が設定できなくて、辞書が読み込めなかったりしていました。

確認よろしくお願いします。