### PR TITLE
fix: can't convert okuri string properly when mode changed

### DIFF
--- a/denops/skkeleton/function/common.ts
+++ b/denops/skkeleton/function/common.ts
@@ -19,7 +19,10 @@ export async function kakutei(context: Context) {
           candidate,
         );
       }
-      const ret = (candidateStrip ?? "error") + state.okuriFeed;
+      const okuriStr = state.converter
+        ? state.converter(state.okuriFeed)
+        : state.okuriFeed;
+      const ret = (candidateStrip ?? "error") + okuriStr;
       context.kakuteiWithUndoPoint(ret);
       break;
     }

--- a/denops/skkeleton/function/jisyo.ts
+++ b/denops/skkeleton/function/jisyo.ts
@@ -1,9 +1,9 @@
 import { config } from "../config.ts";
 import { Context } from "../context.ts";
 import { batch, fn, mapping, op, vars } from "../deps.ts";
-import { currentLibrary } from "../jisyo.ts";
 import { currentContext } from "../main.ts";
-import { HenkanState, initializeState } from "../state.ts";
+import { HenkanState } from "../state.ts";
+import { kakutei } from "./common.ts";
 
 const cmapKeys = ["<Esc>", "<C-g>"];
 
@@ -35,14 +35,9 @@ export async function jisyoTouroku(context: Context): Promise<boolean> {
     if (!input) {
       return false;
     }
-    currentLibrary.get().registerCandidate(
-      state.mode,
-      state.word,
-      input,
-    );
-    const result = input + (okuri ? state.okuriFeed : "");
-    context.kakuteiWithUndoPoint(result);
-    initializeState(state);
+    state.candidates = [input];
+    state.candidateIndex = 0;
+    await kakutei(context);
     return true;
   } catch (e) {
     if (config.debug) {

--- a/denops/skkeleton/function/mode_test.ts
+++ b/denops/skkeleton/function/mode_test.ts
@@ -1,9 +1,12 @@
 import { autocmd, Denops, vars } from "../deps.ts";
 import { test } from "../deps/denops_test.ts";
 import { assertEquals } from "../deps/std/testing.ts";
+import { currentLibrary } from "../jisyo.ts";
 import { currentContext } from "../main.ts";
 import { initDenops } from "../testutil.ts";
+import { kakutei } from "./common.ts";
 import { hankatakana, katakana, zenkaku } from "./mode.ts";
+import { dispatch } from "./testutil.ts";
 
 test({
   mode: "all",
@@ -48,5 +51,26 @@ test({
     assertEquals(await vars.g.get(d, "skkeleton#mode_actual"), "hankata");
     await zenkaku(currentContext.get());
     assertEquals(await vars.g.get(d, "skkeleton#mode_actual"), "zenkaku");
+  },
+});
+
+Deno.test({
+  name: "can convert okuri string properly when mode changed",
+  async fn() {
+    const lib = currentLibrary.get();
+    await lib.registerCandidate("okuriari", "はg", "剥");
+    const context = currentContext.init();
+
+    await katakana(context);
+    await dispatch(context, ";ha;ge");
+    assertEquals(context.toString(), "▼剥ゲ");
+    await kakutei(context);
+    assertEquals(context.preEdit.output(""), "剥ゲ");
+
+    await hankatakana(context);
+    await dispatch(context, ";ha;ge");
+    assertEquals(context.toString(), "▼剥ｹﾞ");
+    await kakutei(context);
+    assertEquals(context.preEdit.output(""), "剥ｹﾞ");
   },
 });

--- a/denops/skkeleton/state.ts
+++ b/denops/skkeleton/state.ts
@@ -80,7 +80,10 @@ export type HenkanState = Omit<InputState, "type"> & {
 export function henkanStateToString(state: HenkanState): string {
   const candidate =
     state.candidates[state.candidateIndex]?.replace(/;.*/, "") ?? "error";
-  return config.markerHenkanSelect + candidate + state.okuriFeed;
+  const okuriStr = state.converter
+    ? state.converter(state.okuriFeed)
+    : state.okuriFeed;
+  return config.markerHenkanSelect + candidate + okuriStr;
 }
 
 export type EscapeState = {


### PR DESCRIPTION
カタカナモードで送り仮名ありの変換をすると送り仮名がひらがなになっていたので直しました