### PR TITLE
fix: skkeleton-toggle calls skkeleton-disable before skkeleton-enable

### DIFF
--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -260,7 +260,8 @@ export async function main(denops: Denops) {
     },
     async toggle(key: unknown, vimStatus: unknown): Promise<string> {
       await init(denops);
-      if (await denops.eval("&l:iminsert") !== 1) {
+      const mode = await vars.g.get(denops, "skkeleton#mode", "");
+      if (await denops.eval("&l:iminsert") !== 1 || mode === "") {
         return await enable(key, vimStatus);
       } else {
         return await disable(key, vimStatus);


### PR DESCRIPTION
`<Plug>(skkeleton-toggle)`の中でskkeletonを有効にするか無効にするか判断するとき、
`g:skkeleton#mode`の値も参照することで、有効になっていないのに無効にしようとする場合に対処できると思います。

(例: `<Plug>(skkeleton-toggle)`の前に`<C-^>`してしまったとき)