### PR TITLE
fix: Replace deprecated function

### DIFF
--- a/denops/skkeleton/deps/std/io.ts
+++ b/denops/skkeleton/deps/std/io.ts
@@ -1,1 +1,0 @@
-export { iter } from "https://deno.land/std@0.127.0/io/util.ts";

--- a/denops/skkeleton/deps/std/streams.ts
+++ b/denops/skkeleton/deps/std/streams.ts
@@ -1,0 +1,1 @@
+export { iterateReader } from "https://deno.land/std@0.127.0/streams/conversion.ts";

--- a/denops/skkeleton/jisyo.ts
+++ b/denops/skkeleton/jisyo.ts
@@ -3,7 +3,7 @@ import { encoding } from "./deps/encoding_japanese.ts";
 import { wrap } from "./deps/iterator_helpers.ts";
 import { JpNum } from "./deps/japanese_numeral.ts";
 import { zip } from "./deps/std/collections.ts";
-import { iter } from "./deps/std/io.ts";
+import { iterateReader } from "./deps/std/streams.ts";
 import { ensureArray, isString } from "./deps/unknownutil.ts";
 import { Encode } from "./types.ts";
 import type {
@@ -383,7 +383,7 @@ export class SkkServer implements Dictionary {
     if (!this.#conn) return [];
     await this.#conn.write(encode(`1${word} `, this.requestEncoding));
     const result: string[] = [];
-    for await (const res of iter(this.#conn)) {
+    for await (const res of iterateReader(this.#conn)) {
       const str = decode(res, this.responseEncoding);
       result.push(...(str.at(0) === "4") ? [] : str.split("/").slice(1, -1));
 


### PR DESCRIPTION
Close #71

`iter()` was moved to [`streams/conversion.ts`](https://deno.land/std@0.127.0/streams/conversion.ts) as `iterateReader`.
