### PR TITLE
Add roman number conversion

### DIFF
--- a/denops/skkeleton/deps/roman.ts
+++ b/denops/skkeleton/deps/roman.ts
@@ -1,0 +1,1 @@
+export * as RomanNum from "https://esm.sh/cr-numeral@1.1.3";

--- a/denops/skkeleton/jisyo.ts
+++ b/denops/skkeleton/jisyo.ts
@@ -3,7 +3,7 @@ import { getKanaTable } from "./kana.ts";
 import { encoding } from "./deps/encoding_japanese.ts";
 import { wrap } from "./deps/iterator_helpers.ts";
 import { JpNum } from "./deps/japanese_numeral.ts";
-import { RomanNum }from "./deps/roman.ts"
+import { RomanNum } from "./deps/roman.ts";
 import { zip } from "./deps/std/collections.ts";
 import { iterateReader } from "./deps/std/streams.ts";
 import { assertArray, isString } from "./deps/unknownutil.ts";

--- a/denops/skkeleton/jisyo.ts
+++ b/denops/skkeleton/jisyo.ts
@@ -3,6 +3,7 @@ import { getKanaTable } from "./kana.ts";
 import { encoding } from "./deps/encoding_japanese.ts";
 import { wrap } from "./deps/iterator_helpers.ts";
 import { JpNum } from "./deps/japanese_numeral.ts";
+import { RomanNum }from "./deps/roman.ts"
 import { zip } from "./deps/std/collections.ts";
 import { iterateReader } from "./deps/std/streams.ts";
 import { assertArray, isString } from "./deps/unknownutil.ts";
@@ -30,6 +31,7 @@ function toKanjiModern(n: number): string {
     return kanjiNumbers[parseInt(c)];
   });
 }
+const toRoman: (n: number) => string = RomanNum.convertNumberToRoman;
 const toKanjiClassic: (n: number) => string = JpNum.number2kanji;
 
 function convertNumber(pattern: string, entry: string): string {
@@ -42,7 +44,6 @@ function convertNumber(pattern: string, entry: string): string {
         case "#5":
         case "#6":
         case "#7":
-        case "#8":
         case "#9":
           return e;
         case "#1":
@@ -51,6 +52,8 @@ function convertNumber(pattern: string, entry: string): string {
           return toKanjiModern(parseInt(e));
         case "#3":
           return toKanjiClassic(parseInt(e));
+        case "#8":
+          return toRoman(parseInt(e));
         default:
           return k;
       }

--- a/denops/skkeleton/jisyo_test.ts
+++ b/denops/skkeleton/jisyo_test.ts
@@ -50,7 +50,7 @@ Deno.test({
     const jisyo = wrapDictionary(await load(numJisyo, "euc-jp"));
     const manager = new Library([jisyo]);
     const nasi = await manager.getCandidate("okurinasi", "101ばん");
-    assertEquals(nasi, ["101番", "１０１番", "一〇一番", "百一番"]);
+    assertEquals(nasi, ["101番", "１０１番", "一〇一番", "百一番", "CI番"]);
   },
 });
 

--- a/denops/skkeleton/testdata/numJisyo
+++ b/denops/skkeleton/testdata/numJisyo
@@ -1,3 +1,3 @@
 ;; okuri-ari entries.
 ;; okuri-nasi entries.
-#ばん /#番/#1番/#2番/#3番/
+#ばん /#番/#1番/#2番/#3番/#8番/


### PR DESCRIPTION
http://openlab.ring.gr.jp/skk/wiki/wiki.cgi?page=%CD%D7%CB%BE#p12

     `#8'

    タイプ 8。ローマ数字変換。`1789' を 'MDCCLXXXIX' に変換します。
