### PR TITLE
Fix lua check

### DIFF
--- a/autoload/skkeleton.vim
+++ b/autoload/skkeleton.vim
@@ -77,7 +77,8 @@ endfunction
 function! s:complete_info() abort
   if exists('*pum#visible') && pum#visible()
     return ['pum.vim', pum#complete_info()]
-  elseif has('nvim') && luaeval('pcall(require, "cmp") and require("cmp").visible()')
+  elseif has('nvim') && type(luaeval('pcall(require, "cmp")')) == v:t_dict
+        \ && luaeval('require("cmp").visible()')
     let selected = luaeval('require("cmp").get_active_entry() ~= nil')
     return ['cmp', {'pum_visible': v:true, 'selected': selected ? 1 : -1}]
   else


### PR DESCRIPTION
`luaeval('pcall(require, "cmp")')` はプラグイン未インストールのときでも true を返すことがあります。ちゃんと型をチェックするように修正しました。

Note: これが発覚したのは、テスト用の `cmp.lua` がカレントディレクトリにあったためです。