### PR TITLE
fix: expr(textlock) breaks `denops#plugin#wait()` at some case

### DIFF
--- a/autoload/skkeleton.vim
+++ b/autoload/skkeleton.vim
@@ -7,13 +7,10 @@ let g:skkeleton#enabled = v:false
 let g:skkeleton#mode = ''
 
 function! skkeleton#request(funcname, args) abort
-  call denops#plugin#wait('skkeleton')
-  let ret = denops#request('skkeleton', a:funcname, a:args)
-  if mode() ==# 'n'
+  if denops#plugin#wait('skkeleton') != 0
     return ''
-  else
-    return ret
   endif
+  return denops#request('skkeleton', a:funcname, a:args)
 endfunction
 
 function! s:doautocmd() abort
@@ -106,7 +103,7 @@ function! skkeleton#vim_status() abort
 endfunction
 
 function! skkeleton#handle(func, opts) abort
-  let ret = denops#request('skkeleton', a:func, [a:opts, skkeleton#vim_status()])
+  let ret = skkeleton#request(a:func, [a:opts, skkeleton#vim_status()])
   if ret =~# "^<Cmd>"
     let ret = "\<Cmd>" .. ret[5:] .. "\<CR>"
   endif

--- a/plugin/skkeleton.vim
+++ b/plugin/skkeleton.vim
@@ -3,9 +3,9 @@ if exists('g:loaded_skkeleton') && g:loaded_skkeleton
 endif
 let g:loaded_skkeleton = v:true
 
-noremap! <expr> <Plug>(skkeleton-enable) skkeleton#request('enable', [])
-noremap! <expr> <Plug>(skkeleton-disable) skkeleton#request('disable', [])
-noremap! <expr> <Plug>(skkeleton-toggle) skkeleton#request('toggle', [])
+noremap! <Plug>(skkeleton-enable)  <Cmd>call skkeleton#handle('enable', {})<CR>
+noremap! <Plug>(skkeleton-disable) <Cmd>call skkeleton#handle('disable', {})<CR>
+noremap! <Plug>(skkeleton-toggle)  <Cmd>call skkeleton#handle('toggle', {})<CR>
 autocmd User DenopsPluginPost:skkeleton let g:skkeleton#init = v:true
 
 " Cause unexpected behavior when lmap is empty


### PR DESCRIPTION
exprマッピング(のtextlock)が `denops#plugin#wait()` を失敗させることがあるのでやめる
