### PR TITLE
fix: add words including numbers to candidates

### DIFF
--- a/denops/skkeleton/jisyo.ts
+++ b/denops/skkeleton/jisyo.ts
@@ -140,6 +140,7 @@ export class NumberConvertWrapper implements Dictionary {
     if (word === realWord) {
       return candidate;
     } else {
+      candidate.unshift(...(await this.#inner.getCandidate(type, word)));
       return candidate.map((c) => convertNumber(c, word));
     }
   }
@@ -150,6 +151,7 @@ export class NumberConvertWrapper implements Dictionary {
     if (prefix === realPrefix) {
       return candidates;
     } else {
+      candidates.unshift(...(await this.#inner.getCandidates(prefix, feed)));
       return candidates.map((
         [kana, cand],
       ) => [kana, cand.map((c) => convertNumber(c, prefix))]);

--- a/denops/skkeleton/jisyo_test.ts
+++ b/denops/skkeleton/jisyo_test.ts
@@ -26,6 +26,12 @@ const numJisyo = join(
   "numJisyo",
 );
 
+const numIncludingJisyo = join(
+  dirname(fromFileUrl(import.meta.url)),
+  "testdata",
+  "numIncludingJisyo",
+);
+
 async function load(path: string, encoding: string): Promise<SKKDictionary> {
   const dic = new SKKDictionary();
   await dic.load(path, encoding);
@@ -70,6 +76,18 @@ Deno.test({
     assertEquals(nasi1, ["１一王手"]);
     const nasi2 = await manager.getCandidate("okurinasi", "111おうて");
     assertEquals(nasi2, ["111王手"]);
+  },
+});
+
+Deno.test({
+  name: "get candidates from words that include numbers",
+  async fn() {
+    const jisyo = wrapDictionary(await load(numIncludingJisyo, "utf-8"));
+    const manager = new Library([jisyo]);
+    const nasi1 = await manager.getCandidate("okurinasi", "cat2");
+    assertEquals(nasi1, ["🐈"]);
+    const nasi2 = await manager.getCandidate("okurinasi", "1000001");
+    assertEquals(nasi2, ["東京都千代田区千代田"]);
   },
 });
 

--- a/denops/skkeleton/testdata/numIncludingJisyo
+++ b/denops/skkeleton/testdata/numIncludingJisyo
@@ -1,0 +1,4 @@
+;; okuri-ari entries.
+;; okuri-nasi entries.
+cat2 /🐈/
+1000001 /東京都千代田区千代田/


### PR DESCRIPTION
If a word in a dictionary has any number, let's say "cat2"(🐈) or "100"(💯), it doesn't appear in candidates, and then the word cannot be converted, no matter what word you type.
So I fixed it.