### PR TITLE
feat: can get exact completion item at short input

### DIFF
--- a/denops/skkeleton/jisyo.ts
+++ b/denops/skkeleton/jisyo.ts
@@ -587,12 +587,20 @@ export class Library {
   }
 
   async getCandidates(prefix: string, feed: string): Promise<CompletionData> {
-    if (prefix.length < 2) {
-      return [];
-    }
     const collector = new Map<string, Set<string>>();
-    for (const dic of this.#dictionaries) {
-      gatherCandidates(collector, await dic.getCandidates(prefix, feed));
+    if (prefix.length == 0) {
+      return [];
+    } else if (prefix.length == 1) {
+      for (const dic of this.#dictionaries) {
+        gatherCandidates(collector, [[
+          prefix,
+          await dic.getCandidate("okurinasi", prefix),
+        ]]);
+      }
+    } else {
+      for (const dic of this.#dictionaries) {
+        gatherCandidates(collector, await dic.getCandidates(prefix, feed));
+      }
     }
     return Array.from(collector.entries())
       .map(([kana, cset]) => [kana, Array.from(cset)]);

--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -369,7 +369,6 @@ COMPLETION                                              *skkeleton-completion*
         \     'mark': 'skkeleton',
         \     'matchers': ['skkeleton'],
         \     'sorters': [],
-        \     'minAutoCompleteLength': 2,
         \     'isVolatile': v:true,
         \   },
         \ })
@@ -419,6 +418,9 @@ sticky keyの挙動をeskk.vimに合わせる~
 
 ==============================================================================
 CHANGELOG                                                *skkeleton-changelog*
+
+2023-02-18~
+- 補完で入力が1文字の場合に完全一致した候補を出すようにした
 
 2023-01-24~
 - 有効化直後のモード切り替えイベントでモードの取得ができていなかった


### PR DESCRIPTION
「▽い」のような1文字の候補を入力した際に完全一致する変換候補を補完するようにします