### PR TITLE
かなテーブル(.rules)を読み込めるようにする

### DIFF
--- a/denops/skkeleton/config.ts
+++ b/denops/skkeleton/config.ts
@@ -19,6 +19,7 @@ export const config = {
   immediatelyCancel: true,
   immediatelyJisyoRW: true,
   kanaTable: "rom",
+  globalKanaTableFiles: [] as (string | [string, string])[],
   keepState: false,
   markerHenkan: "▽",
   markerHenkanSelect: "▼",
@@ -65,6 +66,19 @@ const validators: Validators = {
       getKanaTable(x);
     } catch {
       throw TypeError("can't use undefined kanaTable: " + x);
+    }
+  },
+  globalKanaTableFiles: (x): asserts x is (string | [string, string])[] => {
+    if (
+      !isArray(
+        x,
+        (x): x is string | [string, string] =>
+          isString(x) || isArray(x, isString) && x.length === 2,
+      )
+    ) {
+      throw TypeError(
+        "'globalKanaTableFiles' must be array of two string tuple",
+      );
     }
   },
   keepState: assertBoolean,

--- a/denops/skkeleton/config.ts
+++ b/denops/skkeleton/config.ts
@@ -1,3 +1,4 @@
+import { Denops } from "./deps.ts";
 import {
   assertBoolean,
   assertNumber,
@@ -5,8 +6,9 @@ import {
   isArray,
   isString,
 } from "./deps/unknownutil.ts";
-import { getKanaTable } from "./kana.ts";
+import { getKanaTable, loadKanaTableFiles } from "./kana.ts";
 import { Encode, Encoding } from "./types.ts";
+import { homeExpand } from "./util.ts";
 
 export const config = {
   acceptIllegalResult: false,
@@ -112,7 +114,10 @@ const validators: Validators = {
   userJisyo: assertString,
 };
 
-export function setConfig(newConfig: Record<string, unknown>) {
+export async function setConfig(
+  newConfig: Record<string, unknown>,
+  denops: Denops,
+) {
   const cfg = config as Record<string, unknown>;
   const val = validators as Record<string, (x: unknown) => void>;
   if (config.debug) {
@@ -131,4 +136,13 @@ export function setConfig(newConfig: Record<string, unknown>) {
       throw Error(`Illegal option detected: ${e}`);
     }
   }
+
+  const files = config.globalKanaTableFiles.map(async (
+    x,
+  ): Promise<string | [string, string]> =>
+    Array.isArray(x)
+      ? [await homeExpand(x[0], denops), x[1]]
+      : await homeExpand(x, denops)
+  );
+  console.log(await loadKanaTableFiles(await Promise.all(files)));
 }

--- a/denops/skkeleton/config.ts
+++ b/denops/skkeleton/config.ts
@@ -7,21 +7,21 @@ import {
   isString,
 } from "./deps/unknownutil.ts";
 import { getKanaTable, loadKanaTableFiles } from "./kana.ts";
-import { Encode, Encoding } from "./types.ts";
+import { ConfigOptions, Encode, Encoding } from "./types.ts";
 import { homeExpand } from "./util.ts";
 
-export const config = {
+export const config: ConfigOptions = {
   acceptIllegalResult: false,
   completionRankFile: "",
   debug: false,
   eggLikeNewline: false,
-  globalDictionaries: [] as (string | [string, string])[],
+  globalDictionaries: [],
   globalJisyo: "/usr/share/skk/SKK-JISYO.L",
   globalJisyoEncoding: "euc-jp",
   immediatelyCancel: true,
   immediatelyJisyoRW: true,
   kanaTable: "rom",
-  globalKanaTableFiles: [] as (string | [string, string])[],
+  globalKanaTableFiles: [],
   keepState: false,
   markerHenkan: "▽",
   markerHenkanSelect: "▼",
@@ -31,8 +31,8 @@ export const config = {
   showCandidatesCount: 4,
   skkServerHost: "127.0.0.1",
   skkServerPort: 1178,
-  skkServerReqEnc: "euc-jp" as Encoding,
-  skkServerResEnc: "euc-jp" as Encoding,
+  skkServerReqEnc: "euc-jp",
+  skkServerResEnc: "euc-jp",
   usePopup: true,
   useSkkServer: false,
   userJisyo: "~/.skkeleton",

--- a/denops/skkeleton/config.ts
+++ b/denops/skkeleton/config.ts
@@ -144,5 +144,5 @@ export async function setConfig(
       ? [await homeExpand(x[0], denops), x[1]]
       : await homeExpand(x, denops)
   );
-  console.log(await loadKanaTableFiles(await Promise.all(files)));
+  await loadKanaTableFiles(await Promise.all(files));
 }

--- a/denops/skkeleton/jisyo.ts
+++ b/denops/skkeleton/jisyo.ts
@@ -14,6 +14,7 @@ import type {
   RankData,
   SkkServerOptions,
 } from "./types.ts";
+import { readFileWithEncoding } from "./util.ts";
 
 const okuriAriMarker = ";; okuri-ari entries.";
 const okuriNasiMarker = ";; okuri-nasi entries.";
@@ -228,13 +229,12 @@ export class SKKDictionary implements Dictionary {
     return candidates;
   }
 
-  async load(path: string, encoding: string) {
+  load(data: string) {
     let mode = -1;
     this.#okuriAri = new Map();
     this.#okuriNasi = new Map();
     const a: Map<string, string[]>[] = [this.#okuriAri, this.#okuriNasi];
-    const decoder = new TextDecoder(encoding);
-    const lines = decoder.decode(await Deno.readFile(path)).split("\n");
+    const lines = data.split("\n");
     for (const line of lines) {
       if (line === okuriAriMarker) {
         mode = 0;
@@ -633,12 +633,6 @@ export class Library {
   }
 }
 
-const encodingNames: Record<string, string> = {
-  "EUCJP": "euc-jp",
-  "SJIS": "shift-jis",
-  "UTF8": "utf-8",
-};
-
 export async function load(
   globalDictionaryConfig: (string | [string, string])[],
   userDictionaryPath: UserDictionaryPath,
@@ -646,13 +640,10 @@ export async function load(
 ): Promise<Library> {
   const globalDictionaries = await Promise.all(
     globalDictionaryConfig.map(async ([path, encodingName]) => {
-      if (encodingName === "") {
-        const data = await Deno.readFile(path);
-        encodingName = encodingNames[String(encoding.detect(data))];
-      }
       const dict = new SKKDictionary();
       try {
-        await dict.load(path, encodingName);
+        const file = await readFileWithEncoding(path, encodingName);
+        dict.load(file);
       } catch (e) {
         console.error("globalDictionary loading failed");
         console.error(`at ${path}`);

--- a/denops/skkeleton/jisyo_test.ts
+++ b/denops/skkeleton/jisyo_test.ts
@@ -7,6 +7,7 @@ import {
   UserDictionary,
   wrapDictionary,
 } from "./jisyo.ts";
+import { readFileWithEncoding } from "./util.ts";
 
 const globalJisyo = join(
   dirname(fromFileUrl(import.meta.url)),
@@ -34,7 +35,7 @@ const numIncludingJisyo = join(
 
 async function load(path: string, encoding: string): Promise<SKKDictionary> {
   const dic = new SKKDictionary();
-  await dic.load(path, encoding);
+  dic.load(await readFileWithEncoding(path, encoding));
   return dic;
 }
 

--- a/denops/skkeleton/kana.ts
+++ b/denops/skkeleton/kana.ts
@@ -89,6 +89,6 @@ function injectKanaTable(name: string, table: KanaTable, create = false) {
   if (!t[name] && !create) {
     throw Error(`table ${name} is not found.`);
   }
-  t[name] = distinctBy([...table, ...t[name]], (it) => it[0])
+  t[name] = distinctBy([...table, ...t[name] ?? []], (it) => it[0])
     .sort((a, b) => a[0].localeCompare(b[0]));
 }

--- a/denops/skkeleton/kana.ts
+++ b/denops/skkeleton/kana.ts
@@ -57,7 +57,7 @@ export function registerKanaTable(
 
 export async function loadKanaTableFiles(
   payload: (string | [string, string])[],
-): Promise<KanaTable> {
+): Promise<void> {
   const table: KanaTable = [];
 
   const tasks = payload.map(async (v) => {
@@ -78,7 +78,6 @@ export async function loadKanaTableFiles(
 
   await Promise.all(tasks);
   injectKanaTable("rom", table);
-  return table;
 }
 
 /*

--- a/denops/skkeleton/kana.ts
+++ b/denops/skkeleton/kana.ts
@@ -55,12 +55,12 @@ export function registerKanaTable(
   injectKanaTable(name, table, create);
 }
 
-
-export async function loadKanaTableFiles(payload: (string | [string, string])[]): Promise<void> {
-  
+export async function loadKanaTableFiles(
+  payload: (string | [string, string])[],
+): Promise<void> {
   const table: KanaTable = [];
-
-  const tasks = payload.map(async ([path, encodingName]) => {
+  const tasks = payload.map(async (v) => {
+    const [path, encodingName] = Array.isArray(v) ? v : [v, undefined];
     const file = await readFileWithEncoding(path, encodingName);
     const lines = file.split("\n");
     for (const line of lines) {
@@ -76,6 +76,7 @@ export async function loadKanaTableFiles(payload: (string | [string, string])[])
   });
 
   await Promise.all(tasks);
+  console.log(`table: ${table}`);
   injectKanaTable("rom", table);
 }
 

--- a/denops/skkeleton/kana.ts
+++ b/denops/skkeleton/kana.ts
@@ -57,8 +57,9 @@ export function registerKanaTable(
 
 export async function loadKanaTableFiles(
   payload: (string | [string, string])[],
-): Promise<void> {
+): Promise<KanaTable> {
   const table: KanaTable = [];
+
   const tasks = payload.map(async (v) => {
     const [path, encodingName] = Array.isArray(v) ? v : [v, undefined];
     const file = await readFileWithEncoding(path, encodingName);
@@ -76,8 +77,8 @@ export async function loadKanaTableFiles(
   });
 
   await Promise.all(tasks);
-  console.log(`table: ${table}`);
   injectKanaTable("rom", table);
+  return table;
 }
 
 /*

--- a/denops/skkeleton/kana.ts
+++ b/denops/skkeleton/kana.ts
@@ -14,6 +14,7 @@ const tables: Cell<Record<string, KanaTable>> = new Cell(() => ({
 
 export const currentKanaTable = new Cell(() => "rom");
 
+
 export function getKanaTable(name = currentKanaTable.get()): KanaTable {
   const table = tables.get()[name];
   if (!table) {
@@ -21,6 +22,7 @@ export function getKanaTable(name = currentKanaTable.get()): KanaTable {
   }
   return table;
 }
+
 
 function asKanaResult(result: unknown): KanaResult {
   if (typeof result === "string") {
@@ -52,11 +54,20 @@ export function registerKanaTable(
   const table: KanaTable = Object.entries(rawTable).map((
     e,
   ) => [e[0], asKanaResult(e[1])]);
+  injectKanaTable(name, table, create);
+}
+
+
+
+/*
+ * Concat given kanaTable to the table named `name`.
+ * When the table is not found, create if create=true; otherwise throws `table ${name} is not found`.
+ */
+function injectKanaTable(name: string, table: KanaTable, create = false) {
   const t = tables.get();
   if (!t[name] && !create) {
     throw Error(`table ${name} is not found.`);
   }
-  const newTable = distinctBy([...table, ...t[name] ?? []], (it) => it[0])
+  t[name] = distinctBy([...table, ...t[name]], (it) => it[0])
     .sort((a, b) => a[0].localeCompare(b[0]));
-  t[name] = newTable;
 }

--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -10,15 +10,12 @@ import { functions } from "./function.ts";
 import { disable as disableFunc } from "./function/disable.ts";
 import { initializeStateWithAbbrev, modeChange } from "./mode.ts";
 import { load as jisyoLoad, SkkServer } from "./jisyo.ts";
-import {
-  currentKanaTable,
-  loadKanaTableFiles,
-  registerKanaTable,
-} from "./kana.ts";
+import { currentKanaTable, registerKanaTable } from "./kana.ts";
 import { handleKey, registerKeyMap } from "./keymap.ts";
 import { keyToNotation, notationToKey, receiveNotation } from "./notation.ts";
 import { currentContext, currentLibrary } from "./store.ts";
 import type { CompletionData, RankData, SkkServerOptions } from "./types.ts";
+import { homeExpand } from "./util.ts";
 
 type Opts = {
   key: string;
@@ -34,14 +31,6 @@ function assertOpts(x: any): asserts x is Opts {
 }
 
 let initialized = false;
-
-function homeExpand(path: string, homePath: string): string {
-  if (path[0] === "~") {
-    return homePath + path.slice(1);
-  } else {
-    return path;
-  }
-}
 
 async function init(denops: Denops) {
   if (initialized) {
@@ -77,27 +66,26 @@ async function init(denops: Denops) {
     };
     skkServer = new SkkServer(skkServerOptions);
   }
-  const homePath = await fn.expand(denops, "~") as string;
-  const globalDictionaries =
+  const globalDictionaries = await Promise.all(
     (config.globalDictionaries.length === 0
       ? [[config.globalJisyo, config.globalJisyoEncoding]]
       : config.globalDictionaries)
-      .map((
+      .map(async (
         cfg,
-      ): [string, string] => {
+      ): Promise<[string, string]> => {
         if (typeof (cfg) === "string") {
-          return [homeExpand(cfg, homePath), ""];
+          return [await homeExpand(cfg, denops), ""];
         } else {
-          return [homeExpand(cfg[0], homePath), cfg[1]];
+          return [await homeExpand(cfg[0], denops), cfg[1]];
         }
-      });
-  await loadKanaTableFiles(config.globalKanaTableFiles);
+      }),
+  );
   currentLibrary.setInitializer(async () =>
     await jisyoLoad(
       globalDictionaries,
       {
-        path: homeExpand(userJisyo, homePath),
-        rankPath: homeExpand(completionRankFile, homePath),
+        path: await homeExpand(userJisyo, denops),
+        rankPath: await homeExpand(completionRankFile, denops),
       },
       skkServer,
     )
@@ -274,10 +262,10 @@ export async function main(denops: Denops) {
     config.debug = true;
   }
   denops.dispatcher = {
-    config(config: unknown) {
+    async config(config: unknown) {
       assertObject(config);
-      setConfig(config);
-      return Promise.resolve();
+      await setConfig(config, denops);
+      return;
     },
     async registerKeyMap(state: unknown, key: unknown, funcName: unknown) {
       assertString(state);

--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -10,7 +10,11 @@ import { functions } from "./function.ts";
 import { disable as disableFunc } from "./function/disable.ts";
 import { initializeStateWithAbbrev, modeChange } from "./mode.ts";
 import { load as jisyoLoad, SkkServer } from "./jisyo.ts";
-import { currentKanaTable, registerKanaTable } from "./kana.ts";
+import {
+  currentKanaTable,
+  loadKanaTableFiles,
+  registerKanaTable,
+} from "./kana.ts";
 import { handleKey, registerKeyMap } from "./keymap.ts";
 import { keyToNotation, notationToKey, receiveNotation } from "./notation.ts";
 import { currentContext, currentLibrary } from "./store.ts";
@@ -87,6 +91,7 @@ async function init(denops: Denops) {
           return [homeExpand(cfg[0], homePath), cfg[1]];
         }
       });
+  await loadKanaTableFiles(config.globalKanaTableFiles);
   currentLibrary.setInitializer(async () =>
     await jisyoLoad(
       globalDictionaries,

--- a/denops/skkeleton/types.ts
+++ b/denops/skkeleton/types.ts
@@ -36,3 +36,31 @@ export type SkkServerOptions = {
   requestEnc: Encoding;
   responseEnc: Encoding;
 } & Deno.ConnectOptions;
+
+export type ConfigOptions = {
+  acceptIllegalResult: boolean;
+  completionRankFile: string;
+  debug: boolean;
+  eggLikeNewline: boolean;
+  globalDictionaries: (string | [string, string])[];
+  globalJisyo: string;
+  globalJisyoEncoding: Encoding;
+  immediatelyCancel: boolean;
+  immediatelyJisyoRW: boolean;
+  kanaTable: string;
+  globalKanaTableFiles: (string | [string, string])[];
+  keepState: boolean;
+  markerHenkan: string;
+  markerHenkanSelect: string;
+  registerConvertResult: boolean;
+  selectCandidateKeys: string;
+  setUndoPoint: boolean;
+  showCandidatesCount: number;
+  skkServerHost: string;
+  skkServerPort: number;
+  skkServerReqEnc: Encoding;
+  skkServerResEnc: Encoding;
+  usePopup: boolean;
+  useSkkServer: boolean;
+  userJisyo: string;
+};

--- a/denops/skkeleton/util.ts
+++ b/denops/skkeleton/util.ts
@@ -1,3 +1,5 @@
+import { encoding } from "./deps/encoding_japanese.ts";
+
 export class Cell<T> {
   initialized = false;
   initializer: () => T;
@@ -61,4 +63,25 @@ export class LazyCell<T> {
   setInitializer(initializer: () => Promise<T>) {
     this.lazyInitializer = initializer;
   }
+}
+
+const encodingNames: Record<string, string> = {
+  "EUCJP": "euc-jp",
+  "SJIS": "shift-jis",
+  "UTF8": "utf-8",
+};
+
+export async function readFileWithEncoding(
+  path: string,
+  encodingName: string | undefined,
+): Promise<string> {
+  const uint = await Deno.readFile(path);
+
+  // Use the argument if provided, otherwise try to detect the encoding.
+  const fileEncoding = encodingName !== undefined && encodingName !== ""
+    ? encodingName
+    : encodingNames[String(encoding.detect(uint))];
+
+  const decoder = new TextDecoder(fileEncoding);
+  return decoder.decode(uint);
 }

--- a/denops/skkeleton/util.ts
+++ b/denops/skkeleton/util.ts
@@ -66,12 +66,12 @@ export class LazyCell<T> {
   }
 }
 
-let homePath: string | null = null;
+let homePath: string | undefined = undefined;
 export async function homeExpand(
   path: string,
   denops: Denops,
 ): Promise<string> {
-  if (homePath === null) {
+  if (homePath === undefined) {
     homePath = await fn.expand(denops, "~") as string;
   }
   if (path[0] === "~") {

--- a/denops/skkeleton/util.ts
+++ b/denops/skkeleton/util.ts
@@ -66,11 +66,14 @@ export class LazyCell<T> {
   }
 }
 
+let homePath: string | null = null;
 export async function homeExpand(
   path: string,
   denops: Denops,
 ): Promise<string> {
-  const homePath = await fn.expand(denops, "~") as string;
+  if (homePath === null) {
+    homePath = await fn.expand(denops, "~") as string;
+  }
   if (path[0] === "~") {
     return homePath + path.slice(1);
   } else {

--- a/denops/skkeleton/util.ts
+++ b/denops/skkeleton/util.ts
@@ -1,3 +1,4 @@
+import { Denops, fn } from "./deps.ts";
 import { encoding } from "./deps/encoding_japanese.ts";
 
 export class Cell<T> {
@@ -62,6 +63,18 @@ export class LazyCell<T> {
 
   setInitializer(initializer: () => Promise<T>) {
     this.lazyInitializer = initializer;
+  }
+}
+
+export async function homeExpand(
+  path: string,
+  denops: Denops,
+): Promise<string> {
+  const homePath = await fn.expand(denops, "~") as string;
+  if (path[0] === "~") {
+    return homePath + path.slice(1);
+  } else {
+    return path;
   }
 }
 

--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -196,6 +196,7 @@ globalDictionaries                       *skkeleton-config-globalDictionaries*
     値の例: [["/usr/share/skk/SKK-JISYO.L", "euc-jp"],
              "~/.skk/SKK-JISYO.emoji"]
 <
+
 globalJisyo                                     *skkeleton-config-globalJisyo*
         (デフォルト "/usr/share/skk/SKK-JISYO.L")
         グローバル辞書のパス
@@ -230,7 +231,15 @@ kanaTable                                         *skkeleton-config-kanaTable*
         存在するテーブルのみ指定できます。存在しないテーブルを指定したい場合は
         |skkeleton#register_kanatable()| で先にテーブルを作成してください。
 
-
+globalKanaTableFiles                    *skkeleton-config-globalKanaTableFiles*
+        (デフォルト [])
+        複数のカナ変換テーブルを使用する際に指定するオプションです。
+        指定する値はグローバル辞書のパスまたは
+        パスとエンコーディングからなるタプルの配列になります。
+        エンコーディングを指定しない場合は自動判定されます。
+>
+    値の例: [["/usr/share/skk/azik_us.rule, "euc-jp"]]
+<
 keepState                                         *skkeleton-config-keepState*
         (デフォルト v:false)
         このオプションを有効にすると


### PR DESCRIPTION
### 簡単な説明
SKKの「拡張設定ファイル」をかなテーブルとして読み込めるようにします。 (configの`globalKanaTableFiles`)
<br />

### 動作例
AZIKの拡張設定を読みこんだ様子です。
azik_us.ruleを読みこむことで、`xa→しゃ` `jk→じん` などのローマ字入力が追加されています
(動画にて読みこんでいる.ruleは私のdotfilesにあるものです)
https://github.com/AsPulse/dotfiles-mac/blob/ccf0703b7cae0965b7c43bb49d0246ccaff29236/AquaSKK/azik_us.rule#L100-L111

https://github.com/vim-skk/skkeleton/assets/84216737/0014fe2d-3b5c-40c4-bb32-98d68ce67a55

<br />

### 変更箇所
今まで かなテーブルを編集したり、ファイルを読みこんだりするのが一箇所だったので  
必然的に共通化みたいなことを多くすることになりました……。

 - **`readFileWithEncoding` 関数を追加しました。**
   エンコーディング指定してファイルを読みこむ処理は`globalDictionaries`のみだったのですが、今回追加する`globalKanaTableFiles`もこの処理を行うので共通化しました。

- **`homeExpand`関数が`homePath: string`の代わりに`denops: Denops`を取るようになり、`utils.ts`へ移動しました**
  同じく`homeExpand`を使っていたのはinit内のみだったのですが、config内でも使うようになったため共通化しました。

- **`injectKanaTable`関数を追加しました。**
  渡された`kanaTable`をグローバル変数の`tables`と結合するだけの関数です。
  registerKanaTableと処理が重複するので追加しました

以下が当該PRに直接関係する変更です.ᐟ.ᐟ.ᐟ
- **configに`globalKanaTableFiles`を追加しました**  
   `globalDictionaries`と同じノリで書けるように意識しました。
   helpも書き方を調べ書いてみましたが、書きなれていないので間違いがあれば教えて頂けると嬉しいです。
- **config読み込み時(`setConfig`)にかなテーブルをファイルから読みこむようになりました。**
   `injectKanaTable`で`rom`テーブルを書きかえています。

<br />

**参考追加情報**
- macOS バージョン13.3.1 (a)（ビルド22E772610a）
- NVIM v0.10.0-dev-1368+gbc66b755f-Homebrew
- deno v1.33.3
- denops v5.0.0
- denops-lazy `aee18b3`
- AZIKはいいぞ。