### PR TITLE
Remove import `gather` deleted in denops v5

### DIFF
--- a/denops/skkeleton/deps.ts
+++ b/denops/skkeleton/deps.ts
@@ -1,9 +1,6 @@
 export * as autocmd from "https://deno.land/x/denops_std@v5.0.0/autocmd/mod.ts";
 export * as fn from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
-export {
-  batch,
-  gather,
-} from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
+export { batch } from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
 export type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
 export * as mapping from "https://deno.land/x/denops_std@v5.0.0/mapping/mod.ts";
 export * as vars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";


### PR DESCRIPTION
gatherはどこでも使われていないようなので、collectに置き換えるのではなく完全に削除する