### PR TITLE
Remove some default mappings

### DIFF
--- a/autoload/skkeleton.vim
+++ b/autoload/skkeleton.vim
@@ -116,7 +116,6 @@ function! skkeleton#handle(func, opts) abort
   endif
 endfunction
 
-" copied from eskk.vim
 function! skkeleton#get_default_mapped_keys() abort "{{{
     return split(
                 \   'abcdefghijklmnopqrstuvwxyz'
@@ -134,8 +133,6 @@ function! skkeleton#get_default_mapped_keys() abort "{{{
                 \   '<C-h>',
                 \   '<CR>',
                 \   '<Space>',
-                \   '<C-Space>',
-                \   '<S-Space>',
                 \   '<C-q>',
                 \   '<PageUp>',
                 \   '<PageDown>',

--- a/denops/skkeleton/keymap.ts
+++ b/denops/skkeleton/keymap.ts
@@ -5,7 +5,6 @@ import { cancel, kakutei, newline, purgeCandidate } from "./function/common.ts";
 import { escape } from "./function/disable.ts";
 import {
   henkanBackward,
-  henkanFirst,
   henkanForward,
   henkanInput,
 } from "./function/henkan.ts";

--- a/denops/skkeleton/keymap.ts
+++ b/denops/skkeleton/keymap.ts
@@ -28,8 +28,6 @@ const input: KeyMap = {
     "<esc>": escape,
     "<nl>": kakutei,
     "<c-q>": hankatakana,
-    "<c-space>": henkanFirst,
-    "<s-space>": henkanFirst,
   },
 };
 
@@ -40,8 +38,6 @@ const henkan: KeyMap = {
     "<cr>": newline,
     "<nl>": kakutei,
     "<space>": henkanForward,
-    "<s-space>": henkanForward,
-    "<c-space>": henkanForward,
     "x": henkanBackward,
     "X": purgeCandidate,
   },

--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -115,20 +115,16 @@ KEYMAPPINGS                                            *skkeleton-keymappings*
 
 input:
         <BS>      : |skkeleton-functions-deleteChar|
-        <C-Space> : |skkeleton-functions-henkanFirst|
         <C-g>     : |skkeleton-functions-cancel|
         <C-h>     : |skkeleton-functions-deleteChar|
         <C-q>     : |skkeleton-functions-hankatakana|
         <CR>      : |skkeleton-functions-newline|
         <Esc>     : |skkeleton-functions-escape|
         <NL>      : |skkeleton-functions-kakutei|
-        <S-Space> : |skkeleton-functions-henkanFirst|
 henkan:
-        <C-Space> : |skkeleton-functions-henkanForward|
         <C-g>     : |skkeleton-functions-cancel|
         <CR>      : |skkeleton-functions-newline|
         <NL>      : |skkeleton-functions-kakutei|
-        <S-Space> : |skkeleton-functions-henkanForward|
         <Space>   : |skkeleton-functions-henkanForward|
         X         : |skkeleton-function-purgeCandidate|
         x         : |skkeleton-function-henkanBackward|


### PR DESCRIPTION
`<C-space>`, `<S-space>` のマッピングを削除します。副作用が大きいためです。