### PR TITLE
feat: add state view via g:skkeleton#state

### DIFF
--- a/autoload/skkeleton.vim
+++ b/autoload/skkeleton.vim
@@ -5,6 +5,9 @@ augroup END
 
 let g:skkeleton#enabled = v:false
 let g:skkeleton#mode = ''
+let g:skkeleton#state = #{
+\   phase: '',
+\ }
 
 function! skkeleton#request(funcname, args) abort
   if denops#plugin#wait('skkeleton') != 0
@@ -105,14 +108,16 @@ endfunction
 
 function! skkeleton#handle(func, opts) abort
   let ret = skkeleton#request(a:func, [a:opts, skkeleton#vim_status()])
-  if ret =~# "^<Cmd>"
-    let ret = "\<Cmd>" .. ret[5:] .. "\<CR>"
+  let g:skkeleton#state = ret.state
+  let result = ret.result
+  if result =~# "^<Cmd>"
+    let result = "\<Cmd>" .. result[5:] .. "\<CR>"
   endif
   call skkeleton#doautocmd()
   if get(a:opts, 'expr', v:false)
-    return ret
+    return result
   else
-    call feedkeys(ret, 'nit')
+    call feedkeys(result, 'nit')
   endif
 endfunction
 

--- a/denops/skkeleton/function/disable_test.ts
+++ b/denops/skkeleton/function/disable_test.ts
@@ -5,6 +5,11 @@ import { currentContext } from "../store.ts";
 import { initDenops } from "../testutil.ts";
 import { dispatch } from "./testutil.ts";
 
+// deno-lint-ignore no-explicit-any
+async function getResult(x: Promise<any>): Promise<string> {
+  return (await x)?.result;
+}
+
 test({
   mode: "all",
   name: "kakutei at disable",
@@ -14,9 +19,15 @@ test({
 
     await denops.dispatch("skkeleton", "enable");
     await dispatch(currentContext.get(), " ");
-    assertEquals(await denops.dispatch("skkeleton", "disable"), " \x1e");
+    assertEquals(
+      await getResult(denops.dispatch("skkeleton", "disable")),
+      " \x1e",
+    );
     await denops.dispatch("skkeleton", "enable");
     await dispatch(currentContext.get(), "n");
-    assertEquals(await denops.dispatch("skkeleton", "disable"), "ん\x1e");
+    assertEquals(
+      await getResult(denops.dispatch("skkeleton", "disable")),
+      "ん\x1e",
+    );
   },
 });

--- a/denops/skkeleton/function/input_test.ts
+++ b/denops/skkeleton/function/input_test.ts
@@ -139,7 +139,7 @@ test({
     await op.autoindent.setLocal(denops, true);
     await denops.cmd("startinsert");
     await denops.cmd(
-      "inoremap <expr> J denops#request('skkeleton', 'enable', [])",
+      "inoremap J <Cmd>call skkeleton#handle('enable', {})<CR>",
     );
     await denops.call("feedkeys", "iJ\thoge\x0dhoge;hoge\x0d", "tx");
     assertEquals(await denops.call("getline", 1, "$"), [

--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -78,6 +78,10 @@ skkeleton-mode-changed                                *skkeleton-mode-changed*
       autocmd User skkeleton-mode-changed redrawstatus
     augroup END
 <
+skkeleton-handled                                          *skkeleton-handled*
+
+        入力がハンドリングされた後に呼び出されます。
+        呼び出しの前に|g:skkeleton#state|に状態が代入されます。
 
 ------------------------------------------------------------------------------
 KEYMAPPINGS                                            *skkeleton-keymappings*
@@ -146,6 +150,17 @@ skkeleton#mode()                                            *skkeleton#mode()*
                 "hankata": 半角カタカナ
                 "zenkaku": 全角英数
                 "abbrev":  abbrev
+
+g:skkeleton#state                                          *g:skkeleton#state*
+
+        最後にハンドリングが実行された際の状態から生成される値です。
+        以下の内容から構成されます
+
+                phase: 入力の段階
+                    "input"            直接入力
+                    "input:okurinasi"  送りなし入力
+                    "input:okuriari"   送りあり入力
+                    "henkan"           変換
 
 ------------------------------------------------------------------------------
 CONFIG                                                      *skkeleton-config*
@@ -420,6 +435,9 @@ sticky keyの挙動をeskk.vimに合わせる~
 
 ==============================================================================
 CHANGELOG                                                *skkeleton-changelog*
+
+2023-06-23~
+- 状態取得のために|g:skkeleton#state|を追加した
 
 2023-06-17~
 - 伸ばし棒が半角カナの変換対象になっていなかったので修正


### PR DESCRIPTION
#113 を解決します。

変数 `g:skkeleton#state` 及び、それにアクセスするためのイベント `skkeleton-handled` を追加します。

`g:skkeleton#state` は現時点で以下の要素を持ちます。

```
phase: 入力の段階
    "input"            直接入力
    "input:okurinasi"  送りなし入力
    "input:okuriari"   送りあり入力
    "henkan"           変換
```
