### PR TITLE
feat: can immediately convert at っ when okuriari mode

### DIFF
--- a/denops/skkeleton/config.ts
+++ b/denops/skkeleton/config.ts
@@ -18,10 +18,11 @@ export const config: ConfigOptions = {
   globalDictionaries: [],
   globalJisyo: "/usr/share/skk/SKK-JISYO.L",
   globalJisyoEncoding: "euc-jp",
+  globalKanaTableFiles: [],
   immediatelyCancel: true,
   immediatelyJisyoRW: true,
+  immediatelyOkuriConvert: true,
   kanaTable: "rom",
-  globalKanaTableFiles: [],
   keepState: false,
   markerHenkan: "▽",
   markerHenkanSelect: "▼",
@@ -60,16 +61,6 @@ const validators: Validators = {
   },
   globalJisyo: assertString,
   globalJisyoEncoding: assertString,
-  immediatelyCancel: assertBoolean,
-  immediatelyJisyoRW: assertBoolean,
-  kanaTable: (x): asserts x is string => {
-    assertString(x);
-    try {
-      getKanaTable(x);
-    } catch {
-      throw TypeError("can't use undefined kanaTable: " + x);
-    }
-  },
   globalKanaTableFiles: (x): asserts x is (string | [string, string])[] => {
     if (
       !isArray(
@@ -81,6 +72,17 @@ const validators: Validators = {
       throw TypeError(
         "'globalKanaTableFiles' must be array of two string tuple",
       );
+    }
+  },
+  immediatelyCancel: assertBoolean,
+  immediatelyJisyoRW: assertBoolean,
+  immediatelyOkuriConvert: assertBoolean,
+  kanaTable: (x): asserts x is string => {
+    assertString(x);
+    try {
+      getKanaTable(x);
+    } catch {
+      throw TypeError("can't use undefined kanaTable: " + x);
     }
   },
   keepState: assertBoolean,

--- a/denops/skkeleton/config_test.ts
+++ b/denops/skkeleton/config_test.ts
@@ -8,6 +8,8 @@ const defaultConfig = { ...config };
 
 const lib = await currentLibrary.get();
 lib.registerCandidate("okurinasi", "あ", "あ");
+lib.registerCandidate("okuriari", "あt", "会");
+lib.registerCandidate("okuriari", "すp", "酸");
 
 Deno.test({
   name: "egg like newline",
@@ -38,6 +40,26 @@ Deno.test({
       const context = new Context();
       await dispatch(context, "ksa");
       assertEquals(context.preEdit.output(""), "kさ");
+    }
+  },
+});
+
+Deno.test({
+  name: "immediatelyOkuriConvert",
+  async fn() {
+    // true
+    {
+      Object.assign(config, defaultConfig);
+      const context = new Context();
+      await dispatch(context, ";a;xtu");
+      assertEquals(context.toString(), "▼会っ");
+    }
+    // false
+    {
+      config.immediatelyOkuriConvert = false;
+      const context = new Context();
+      await dispatch(context, ";su;xtupa");
+      assertEquals(context.toString(), "▼酸っぱ");
     }
   },
 });

--- a/denops/skkeleton/function/input.ts
+++ b/denops/skkeleton/function/input.ts
@@ -57,9 +57,16 @@ async function doKakutei(
     return;
   }
   kakuteiKana(state, preEdit, kana, feed);
-  // 直接入力などで「使った」のように打つ時「つかっ」の段階では変換をしない
-  if (state.mode === "okuriari" && !feed && state.okuriFeed.at(-1) !== "っ") {
-    await henkanFirst(context, "");
+  if (state.mode === "okuriari" && feed === "") {
+    if (state.okuriFeed.at(-1) === "っ") {
+      // immediatelyOkuriConvertが有効になっていない場合
+      // 直接入力などで「使った」のように打つ時「つかっ」の段階では変換をしない
+      if (config.immediatelyOkuriConvert) {
+        await henkanFirst(context, "");
+      }
+    } else {
+      await henkanFirst(context, "");
+    }
   }
 }
 

--- a/denops/skkeleton/okuri.ts
+++ b/denops/skkeleton/okuri.ts
@@ -85,6 +85,13 @@ const okuriTable: Record<string, string> = {
 };
 
 export function getOkuriStr(word: string, okuri: string): string {
+  // 「送っ」のような段階で変換する際は、タ行の入力がされているように振る舞う
+  // libskkなどはこの動作を行う
+  // 根拠として、促音のほとんどがタ行という調査結果が挙げられる
+  // https://blog.atusy.net/2023/08/01/skk-azik-and-sokuon-okuri/
+  if (okuri === "っ") {
+    return word + "t";
+  }
   const alpha = okuriTable[okuri.match(/[^っ]/)?.[0] ?? ""];
   return word + alpha;
 }

--- a/denops/skkeleton/types.ts
+++ b/denops/skkeleton/types.ts
@@ -45,10 +45,11 @@ export type ConfigOptions = {
   globalDictionaries: (string | [string, string])[];
   globalJisyo: string;
   globalJisyoEncoding: Encoding;
+  globalKanaTableFiles: (string | [string, string])[];
   immediatelyCancel: boolean;
   immediatelyJisyoRW: boolean;
+  immediatelyOkuriConvert: boolean;
   kanaTable: string;
-  globalKanaTableFiles: (string | [string, string])[];
   keepState: boolean;
   markerHenkan: string;
   markerHenkanSelect: string;

--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -243,6 +243,16 @@ immediatelyJisyoRW                       *skkeleton-config-immediatelyJisyoRW*
         変換や確定の度にユーザー辞書を読み書きするようになります。
         複数のVimインスタンスを同時に使う場合に有用かもしれません。
 
+immediatelyOkuriConvert             *skkeleton-config-immediatelyOkuriConvert*
+        (デフォルト v:true)
+        有効にすると、送りあり変換時に直接「っ」を打った時点で
+        タ行の送り仮名が打たれたと判断し変換を開始します。
+        Note: ローマ時入力で連続入力で「っ」を入力する場合など、続く文字が
+              入力される場合には影響しません。
+        Note: 機能追加に際しタ行決め打ちにする根拠を調査して頂いたので
+              載せておきます。
+              https://blog.atusy.net/2023/08/01/skk-azik-and-sokuon-okuri/
+
 kanaTable                                         *skkeleton-config-kanaTable*
         (デフォルト "rom")
         使用する仮名テーブルを指定します。


### PR DESCRIPTION
送りあり変換で「ひるがえっ」等と打った段階でタ行扱いして「翻っ」のように変換する機能を追加します。
これにより #138 が解決する予定です。