### PR TITLE
fix: Avoid denops's async requesting error

### DIFF
--- a/denops/@ddc-sources/skkeleton.ts
+++ b/denops/@ddc-sources/skkeleton.ts
@@ -47,8 +47,9 @@ export class Source extends BaseSource<Params> {
     // グローバル辞書由来の候補はユーザー辞書の末尾より配置する
     // 辞書順に並べるため先頭から順に負の方向にランクを振っていく
     let globalRank = -1;
-    const config = await args.denops.call(
-      "skkeleton#get_config",
+    const config = await args.denops.dispatch(
+      "skkeleton",
+      "getConfig",
     ) as ConfigOptions;
     const abbrPrefix = " ".repeat(
       await fn.strwidth(args.denops, config.markerHenkan),


### PR DESCRIPTION
denops.call("denops#request", "foo") in source.gather() may cause errors of [denops-268](https://github.com/vim-denops/denops.vim/issues/268).

This patch fixes that.

But, I don't know that this is best way to fix this issue. I'm not a expert of denops.vim and neovim rpc.