### PR TITLE
Fix a bug, where you cannot register a single capital letter with skkeleton#register_keymap().

### DIFF
--- a/autoload/skkeleton.vim
+++ b/autoload/skkeleton.vim
@@ -65,7 +65,9 @@ function! skkeleton#register_keymap(state, key, func_name)
   if 1 < strlen(key) && key[0] ==# '<'
     let key = eval('"\' .. key .. '"')
   endif
-  let key = get(g:skkeleton#notation#key_to_notation, key, key)
+  if key !~# '^[A-Z]$'
+    let key = get(g:skkeleton#notation#key_to_notation, key, key)
+  endif
 
   if len(key) != 1
     let key = tolower(key)

--- a/denops/skkeleton/keymap_test.ts
+++ b/denops/skkeleton/keymap_test.ts
@@ -33,6 +33,26 @@ test({
     await denops.cmd('call skkeleton#handle("handleKey", {"key": " "})');
     await denops.cmd('call skkeleton#handle("handleKey", {"key": "<bs>"})');
     assertEquals(currentContext.get().toString(), "▽あ");
+
+    currentContext.init().denops = denops;
+
+    // register a keymap that consists of a single capital letter
+    await denops.cmd(
+      'call skkeleton#register_keymap("henkan", "B", "henkanBackward")',
+    );
+    await denops.cmd('call skkeleton#handle("handleKey", {"key": "A"})');
+    await denops.cmd('call skkeleton#handle("handleKey", {"key": " "})');
+    await denops.cmd('call skkeleton#handle("handleKey", {"key": "B"})');
+    assertEquals(currentContext.get().toString(), "▽あ");
+
+    currentContext.init().denops = denops;
+
+    // remove a keymap registered above
+    await denops.cmd('call skkeleton#register_keymap("henkan", "B", "")');
+    await denops.cmd('call skkeleton#handle("handleKey", {"key": "A"})');
+    await denops.cmd('call skkeleton#handle("handleKey", {"key": " "})');
+    await denops.cmd('call skkeleton#handle("handleKey", {"key": "B"})');
+    assertEquals(currentContext.get().toString(), "▽b");
   },
 });
 


### PR DESCRIPTION
`skkeleton#register_keymap()`に大文字を一文字だけ(例えば`A`)登録すると、`keyMap.map`のキーの値は`<s-a>`になります。
一方、`keymap.ts`の`handleKey()`では、`notationToKey[key] ?? key`の結果`registerKeyMap()`に`A`を渡しており、マップが参照できなくなっていました。
https://github.com/vim-skk/skkeleton/blob/fbdfe6e48de08d9ca1116683b796de95bd6ef83c/denops/skkeleton/keymap.ts#L50-L62


