### PR TITLE
Remove macos runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         runner:
           # - windows-latest
-          - macos-latest
+          # - macos-latest
           - ubuntu-latest
         version:
           - "1.32.0"


### PR DESCRIPTION
macOS の Runner は頻繁に失敗するので無意味だとおもいます