### PR TITLE
Rename getCandidate() and getCandidates()

### DIFF
--- a/denops/@ddc-sources/skkeleton.ts
+++ b/denops/@ddc-sources/skkeleton.ts
@@ -32,7 +32,7 @@ export class Source extends BaseSource<Params> {
   ): Promise<DdcGatherItems> {
     const candidates = (await args.denops.dispatch(
       "skkeleton",
-      "getCandidates",
+      "getCompletionResult",
     )) as CompletionData;
     const ranks = new Map(
       (await args.denops

--- a/denops/skkeleton/config_test.ts
+++ b/denops/skkeleton/config_test.ts
@@ -7,9 +7,9 @@ import { currentLibrary } from "./store.ts";
 const defaultConfig = { ...config };
 
 const lib = await currentLibrary.get();
-lib.registerCandidate("okurinasi", "あ", "あ");
-lib.registerCandidate("okuriari", "あt", "会");
-lib.registerCandidate("okuriari", "すp", "酸");
+lib.registerHenkanResult("okurinasi", "あ", "あ");
+lib.registerHenkanResult("okuriari", "あt", "会");
+lib.registerHenkanResult("okuriari", "すp", "酸");
 
 Deno.test({
   name: "egg like newline",

--- a/denops/skkeleton/function/common.ts
+++ b/denops/skkeleton/function/common.ts
@@ -15,7 +15,7 @@ export async function kakutei(context: Context) {
       const candidateStrip = candidate?.replace(/;.*/, "");
       if (candidate) {
         const lib = await currentLibrary.get();
-        await lib.registerCandidate(
+        await lib.registerHenkanResult(
           state.mode,
           state.word,
           candidate,

--- a/denops/skkeleton/function/common_test.ts
+++ b/denops/skkeleton/function/common_test.ts
@@ -8,7 +8,11 @@ import { dispatch } from "./testutil.ts";
 const lib = await currentLibrary.get();
 
 await lib.registerHenkanResult("okurinasi", "あ", "い");
-await lib.registerHenkanResult("okurinasi", "ちゅうしゃく", "注釈;これは注釈です");
+await lib.registerHenkanResult(
+  "okurinasi",
+  "ちゅうしゃく",
+  "注釈;これは注釈です",
+);
 
 Deno.test({
   name: "input cancel",

--- a/denops/skkeleton/function/common_test.ts
+++ b/denops/skkeleton/function/common_test.ts
@@ -7,8 +7,8 @@ import { dispatch } from "./testutil.ts";
 
 const lib = await currentLibrary.get();
 
-await lib.registerCandidate("okurinasi", "あ", "い");
-await lib.registerCandidate("okurinasi", "ちゅうしゃく", "注釈;これは注釈です");
+await lib.registerHenkanResult("okurinasi", "あ", "い");
+await lib.registerHenkanResult("okurinasi", "ちゅうしゃく", "注釈;これは注釈です");
 
 Deno.test({
   name: "input cancel",
@@ -39,7 +39,7 @@ Deno.test({
     assertEquals("注釈", context.preEdit.output(""));
     assertEquals(
       ["注釈;これは注釈です"],
-      await lib.getCandidate("okurinasi", "ちゅうしゃく"),
+      await lib.getHenkanResult("okurinasi", "ちゅうしゃく"),
     );
   },
 });

--- a/denops/skkeleton/function/henkan.ts
+++ b/denops/skkeleton/function/henkan.ts
@@ -36,7 +36,7 @@ export async function henkanFirst(context: Context, key: string) {
     ? state.henkanFeed
     : getOkuriStr(state.henkanFeed, state.okuriFeed);
   state.word = word;
-  state.candidates = await lib.getCandidate(state.mode, word);
+  state.candidates = await lib.getHenkanResult(state.mode, word);
   await henkanForward(context);
 }
 

--- a/denops/skkeleton/function/henkan_test.ts
+++ b/denops/skkeleton/function/henkan_test.ts
@@ -4,12 +4,12 @@ import { currentLibrary } from "../store.ts";
 import { dispatch } from "./testutil.ts";
 
 const l = await currentLibrary.get();
-await l.registerCandidate("okurinasi", "へんかん", "返還");
-await l.registerCandidate("okurinasi", "へんかん", "変換");
-await l.registerCandidate("okuriari", "おくr", "送");
-await l.registerCandidate("okuriari", "えらn", "選");
-await l.registerCandidate("okuriari", "うたがt", "疑");
-await l.registerCandidate("okuriari", "うたがc", "疑");
+await l.registerHenkanResult("okurinasi", "へんかん", "返還");
+await l.registerHenkanResult("okurinasi", "へんかん", "変換");
+await l.registerHenkanResult("okuriari", "おくr", "送");
+await l.registerHenkanResult("okuriari", "えらn", "選");
+await l.registerHenkanResult("okuriari", "うたがt", "疑");
+await l.registerHenkanResult("okuriari", "うたがc", "疑");
 
 Deno.test({
   name: "okurinasi henkan",

--- a/denops/skkeleton/function/mode.ts
+++ b/denops/skkeleton/function/mode.ts
@@ -57,7 +57,7 @@ export async function katakana(context: Context) {
     result = hiraToKata(result);
     if (config.registerConvertResult) {
       const lib = await currentLibrary.get();
-      await lib.registerCandidate("okurinasi", kana, result);
+      await lib.registerHenkanResult("okurinasi", kana, result);
       context.lastCandidate = {
         type: "okurinasi",
         word: kana,
@@ -95,7 +95,7 @@ export async function hankatakana(context: Context) {
     result = hiraToHanKata(result);
     if (config.registerConvertResult) {
       const lib = await currentLibrary.get();
-      await lib.registerCandidate("okurinasi", kana, result);
+      await lib.registerHenkanResult("okurinasi", kana, result);
       context.lastCandidate = {
         type: "okurinasi",
         word: kana,

--- a/denops/skkeleton/function/mode_test.ts
+++ b/denops/skkeleton/function/mode_test.ts
@@ -61,7 +61,7 @@ Deno.test({
   name: "can convert okuri string properly when mode changed",
   async fn() {
     const lib = await currentLibrary.get();
-    await lib.registerCandidate("okuriari", "はg", "剥");
+    await lib.registerHenkanResult("okuriari", "はg", "剥");
     const context = currentContext.init();
 
     await katakana(context);

--- a/denops/skkeleton/jisyo.ts
+++ b/denops/skkeleton/jisyo.ts
@@ -148,13 +148,18 @@ export class NumberConvertWrapper implements Dictionary {
     }
   }
 
-  async getCompletionResult(prefix: string, feed: string): Promise<CompletionData> {
+  async getCompletionResult(
+    prefix: string,
+    feed: string,
+  ): Promise<CompletionData> {
     const realPrefix = prefix.replaceAll(/[0-9]+/g, "#");
     const candidates = await this.#inner.getCompletionResult(realPrefix, feed);
     if (prefix === realPrefix) {
       return candidates;
     } else {
-      candidates.unshift(...(await this.#inner.getCompletionResult(prefix, feed)));
+      candidates.unshift(
+        ...(await this.#inner.getCompletionResult(prefix, feed)),
+      );
       return candidates.map((
         [kana, cand],
       ) => [kana, cand.map((c) => convertNumber(c, prefix))]);
@@ -550,7 +555,10 @@ export class SkkServer implements Dictionary {
     }
     return result;
   }
-  async getCompletionResult(prefix: string, feed: string): Promise<CompletionData> {
+  async getCompletionResult(
+    prefix: string,
+    feed: string,
+  ): Promise<CompletionData> {
     if (!this.#conn) return [];
 
     let midashis: string[] = [];
@@ -568,7 +576,10 @@ export class SkkServer implements Dictionary {
 
     const candidates: CompletionData = [];
     for (const midashi of midashis) {
-      candidates.push([midashi, await this.getHenkanResult("okurinasi", midashi)]);
+      candidates.push([
+        midashi,
+        await this.getHenkanResult("okurinasi", midashi),
+      ]);
     }
 
     return candidates;
@@ -669,7 +680,10 @@ export class Library {
     return Array.from(merged);
   }
 
-  async getCompletionResult(prefix: string, feed: string): Promise<CompletionData> {
+  async getCompletionResult(
+    prefix: string,
+    feed: string,
+  ): Promise<CompletionData> {
     if (config.immediatelyJisyoRW) {
       await this.load();
     }
@@ -685,7 +699,10 @@ export class Library {
       }
     } else {
       for (const dic of this.#dictionaries) {
-        gatherCandidates(collector, await dic.getCompletionResult(prefix, feed));
+        gatherCandidates(
+          collector,
+          await dic.getCompletionResult(prefix, feed),
+        );
       }
     }
     return Array.from(collector.entries())
@@ -696,7 +713,11 @@ export class Library {
     return this.#userDictionary.getRanks(prefix);
   }
 
-  async registerHenkanResult(type: HenkanType, word: string, candidate: string) {
+  async registerHenkanResult(
+    type: HenkanType,
+    word: string,
+    candidate: string,
+  ) {
     this.#userDictionary.registerHenkanResult(type, word, candidate);
     if (config.immediatelyJisyoRW) {
       await this.#userDictionary.save();

--- a/denops/skkeleton/jisyo.ts
+++ b/denops/skkeleton/jisyo.ts
@@ -609,10 +609,10 @@ export class SkkServer implements Dictionary {
 
 export class GoogleJapaneseInput implements Dictionary {
   async connect() {}
-  async getCandidate(_type: HenkanType, word: string): Promise<string[]> {
+  async getHenkanResult(_type: HenkanType, word: string): Promise<string[]> {
     return await this.getMidashis(word);
   }
-  getCandidates(_prefix: string, _feed: string): Promise<CompletionData> {
+  getCompletionResult(_prefix: string, _feed: string): Promise<CompletionData> {
     // Note: It does not support completions
     return Promise.resolve([]);
   }

--- a/denops/skkeleton/jisyo_test.ts
+++ b/denops/skkeleton/jisyo_test.ts
@@ -223,7 +223,7 @@ Deno.test({
   async fn() {
     // ランクは保存されていた順序あるいは登録された時刻で表される
     // 適切に比較すると最近登録した物ほど先頭に並ぶようにソートできる
-    // 候補はgetCandidatesの結果によりフィルタリングされる
+    // 候補はgetCompletionResultの結果によりフィルタリングされる
     const dic = new UserDictionary();
     dic.registerHenkanResult("okurinasi", "ほげ", "hoge");
     dic.registerHenkanResult("okurinasi", "ぴよ", "piyo");

--- a/denops/skkeleton/jisyo_test.ts
+++ b/denops/skkeleton/jisyo_test.ts
@@ -144,10 +144,16 @@ Deno.test({
     // most recently registered
     await manager.registerHenkanResult("okurinasi", "test", "a");
     await manager.registerHenkanResult("okurinasi", "test", "b");
-    assertEquals(["b", "a"], await manager.getHenkanResult("okurinasi", "test"));
+    assertEquals(
+      ["b", "a"],
+      await manager.getHenkanResult("okurinasi", "test"),
+    );
     // and remove duplicate
     await manager.registerHenkanResult("okurinasi", "test", "a");
-    assertEquals(["a", "b"], await manager.getHenkanResult("okurinasi", "test"));
+    assertEquals(
+      ["a", "b"],
+      await manager.getHenkanResult("okurinasi", "test"),
+    );
   },
 });
 

--- a/denops/skkeleton/jisyo_test.ts
+++ b/denops/skkeleton/jisyo_test.ts
@@ -62,9 +62,9 @@ Deno.test({
   async fn() {
     const jisyo = await load(newJisyoJson, "utf-8");
     const manager = new Library([jisyo]);
-    const ari = await manager.getCandidate("okuriari", "わるs");
+    const ari = await manager.getHenkanResult("okuriari", "わるs");
     assertEquals(["悪"], ari);
-    const nasi = await manager.getCandidate("okurinasi", "あかね");
+    const nasi = await manager.getHenkanResult("okurinasi", "あかね");
     assertEquals(nasi, ["茜"]);
   },
 });
@@ -74,9 +74,9 @@ Deno.test({
   async fn() {
     const jisyo = await load(newJisyoYaml, "utf-8");
     const manager = new Library([jisyo]);
-    const ari = await manager.getCandidate("okuriari", "わるs");
+    const ari = await manager.getHenkanResult("okuriari", "わるs");
     assertEquals(["悪"], ari);
-    const nasi = await manager.getCandidate("okurinasi", "あかね");
+    const nasi = await manager.getHenkanResult("okurinasi", "あかね");
     assertEquals(nasi, ["茜"]);
   },
 });
@@ -86,9 +86,9 @@ Deno.test({
   async fn() {
     const jisyo = await load(globalJisyo, "euc-jp");
     const manager = new Library([jisyo]);
-    const ari = await manager.getCandidate("okuriari", "てすt");
+    const ari = await manager.getHenkanResult("okuriari", "てすt");
     assertEquals(["テスト"], ari);
-    const nasi = await manager.getCandidate("okurinasi", "てすと");
+    const nasi = await manager.getHenkanResult("okurinasi", "てすと");
     assertEquals(nasi, ["テスト", "test"]);
   },
 });
@@ -98,7 +98,7 @@ Deno.test({
   async fn() {
     const jisyo = wrapDictionary(await load(numJisyo, "euc-jp"));
     const manager = new Library([jisyo]);
-    const nasi = await manager.getCandidate("okurinasi", "101ばん");
+    const nasi = await manager.getHenkanResult("okurinasi", "101ばん");
     assertEquals(nasi, [
       "101番",
       "１０１番",
@@ -117,9 +117,9 @@ Deno.test({
   async fn() {
     const jisyo = wrapDictionary(await load(numJisyo, "euc-jp"));
     const manager = new Library([jisyo]);
-    const nasi1 = await manager.getCandidate("okurinasi", "11おうて");
+    const nasi1 = await manager.getHenkanResult("okurinasi", "11おうて");
     assertEquals(nasi1, ["１一王手"]);
-    const nasi2 = await manager.getCandidate("okurinasi", "111おうて");
+    const nasi2 = await manager.getHenkanResult("okurinasi", "111おうて");
     assertEquals(nasi2, ["111王手"]);
   },
 });
@@ -129,9 +129,9 @@ Deno.test({
   async fn() {
     const jisyo = wrapDictionary(await load(numIncludingJisyo, "utf-8"));
     const manager = new Library([jisyo]);
-    const nasi1 = await manager.getCandidate("okurinasi", "cat2");
+    const nasi1 = await manager.getHenkanResult("okurinasi", "cat2");
     assertEquals(nasi1, ["🐈"]);
-    const nasi2 = await manager.getCandidate("okurinasi", "1000001");
+    const nasi2 = await manager.getHenkanResult("okurinasi", "1000001");
     assertEquals(nasi2, ["東京都千代田区千代田"]);
     //vim-skk/main
   },
@@ -142,12 +142,12 @@ Deno.test({
   async fn() {
     const manager = new Library();
     // most recently registered
-    await manager.registerCandidate("okurinasi", "test", "a");
-    await manager.registerCandidate("okurinasi", "test", "b");
-    assertEquals(["b", "a"], await manager.getCandidate("okurinasi", "test"));
+    await manager.registerHenkanResult("okurinasi", "test", "a");
+    await manager.registerHenkanResult("okurinasi", "test", "b");
+    assertEquals(["b", "a"], await manager.getHenkanResult("okurinasi", "test"));
     // and remove duplicate
-    await manager.registerCandidate("okurinasi", "test", "a");
-    assertEquals(["a", "b"], await manager.getCandidate("okurinasi", "test"));
+    await manager.registerHenkanResult("okurinasi", "test", "a");
+    assertEquals(["a", "b"], await manager.getHenkanResult("okurinasi", "test"));
   },
 });
 
@@ -156,16 +156,16 @@ Deno.test({
   async fn() {
     const jisyo = await load(globalJisyo, "euc-jp");
     const library = new Library([jisyo]);
-    await library.registerCandidate("okurinasi", "てすと", "test");
+    await library.registerHenkanResult("okurinasi", "てすと", "test");
 
     // remove dup
-    const nasi = await library.getCandidate("okurinasi", "てすと");
+    const nasi = await library.getHenkanResult("okurinasi", "てすと");
     assertEquals(["test", "テスト"], nasi);
 
     // new candidate
     // user candidates priority is higher than global
-    await library.registerCandidate("okurinasi", "てすと", "てすと");
-    const nasi2 = await library.getCandidate("okurinasi", "てすと");
+    await library.registerHenkanResult("okurinasi", "てすと", "てすと");
+    const nasi2 = await library.getHenkanResult("okurinasi", "てすと");
     assertEquals(["てすと", "test", "テスト"], nasi2);
   },
 });
@@ -187,10 +187,10 @@ Deno.test({
       // load
       const dic = new UserDictionary();
       await dic.load({ path: tmp });
-      assertEquals(await dic.getCandidate("okurinasi", "あ"), ["あ"]);
+      assertEquals(await dic.getHenkanResult("okurinasi", "あ"), ["あ"]);
 
       //save
-      dic.registerCandidate("okurinasi", "あ", "亜");
+      dic.registerHenkanResult("okurinasi", "あ", "亜");
       await dic.save();
       const data = await Deno.readTextFile(tmp);
       const line = data.split("\n").find((value) => value.startsWith("あ"));
@@ -205,14 +205,14 @@ Deno.test({
   name: "don't register empty candidate",
   async fn() {
     const dic = new UserDictionary();
-    dic.registerCandidate("okurinasi", "ほげ", "");
-    dic.registerCandidate("okuriari", "ほげ", "");
+    dic.registerHenkanResult("okurinasi", "ほげ", "");
+    dic.registerHenkanResult("okuriari", "ほげ", "");
     assertEquals(
-      await dic.getCandidate("okurinasi", "ほげ"),
+      await dic.getHenkanResult("okurinasi", "ほげ"),
       [],
     );
     assertEquals(
-      await dic.getCandidate("okuriari", "ほげ"),
+      await dic.getHenkanResult("okuriari", "ほげ"),
       [],
     );
   },
@@ -225,17 +225,17 @@ Deno.test({
     // 適切に比較すると最近登録した物ほど先頭に並ぶようにソートできる
     // 候補はgetCandidatesの結果によりフィルタリングされる
     const dic = new UserDictionary();
-    dic.registerCandidate("okurinasi", "ほげ", "hoge");
-    dic.registerCandidate("okurinasi", "ぴよ", "piyo");
+    dic.registerHenkanResult("okurinasi", "ほげ", "hoge");
+    dic.registerHenkanResult("okurinasi", "ぴよ", "piyo");
     await new Promise((r) => setTimeout(r, 2));
-    dic.registerCandidate("okurinasi", "ほげほげ", "hogehoge");
+    dic.registerHenkanResult("okurinasi", "ほげほげ", "hogehoge");
     const a = dic.getRanks("ほげ")
       .sort((a, b) => b[1] - a[1])
       .map((e) => e[0]);
     assertEquals(a, ["hogehoge", "hoge"]);
 
     await new Promise((r) => setTimeout(r, 2));
-    dic.registerCandidate("okurinasi", "ほげ", "hoge");
+    dic.registerHenkanResult("okurinasi", "ほげ", "hoge");
     const b = dic.getRanks("ほげ")
       .sort((a, b) => b[1] - a[1])
       .map((e) => e[0]);
@@ -254,12 +254,12 @@ Deno.test({
       [globalJisyo, "euc-jp"],
       [globalJisyo2, "utf-8"],
     ], {});
-    assertEquals(await lib.getCandidate("okurinasi", "てすと"), [
+    assertEquals(await lib.getHenkanResult("okurinasi", "てすと"), [
       "テスト",
       "test",
       "ﾃｽﾄ",
     ]);
-    assertEquals(await lib.getCandidate("okurinasi", "あ"), ["a"]);
-    assertEquals(await lib.getCandidate("okurinasi", "い"), ["i"]);
+    assertEquals(await lib.getHenkanResult("okurinasi", "あ"), ["a"]);
+    assertEquals(await lib.getHenkanResult("okurinasi", "い"), ["i"]);
   },
 });

--- a/denops/skkeleton/keymap_test.ts
+++ b/denops/skkeleton/keymap_test.ts
@@ -11,7 +11,7 @@ test({
   async fn(denops) {
     await initDenops(denops);
     const lib = await currentLibrary.get();
-    lib.registerCandidate("okurinasi", "あ", "亜");
+    lib.registerHenkanResult("okurinasi", "あ", "亜");
     await denops.cmd('call skkeleton#register_keymap("henkan", "x", "")');
     await denops.cmd(
       'call skkeleton#register_keymap("henkan", "<BS>", "henkanBackward")',
@@ -63,8 +63,8 @@ test({
   async fn(denops) {
     await initDenops(denops);
     const lib = await currentLibrary.get();
-    lib.registerCandidate("okurinasi", "われ", "我");
-    lib.registerCandidate("okuriari", "おもu", "思");
+    lib.registerHenkanResult("okurinasi", "われ", "我");
+    lib.registerHenkanResult("okuriari", "おもu", "思");
 
     await denops.cmd(
       'call skkeleton#handle("handleKey", {"key": ["W", "a", "r", "e"]})',

--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -353,13 +353,13 @@ export async function main(denops: Denops) {
       }
       return Promise.resolve(state.henkanFeed);
     },
-    async getCandidates(): Promise<CompletionData> {
+    async getCompletionResult(): Promise<CompletionData> {
       const state = currentContext.get().state;
       if (state.type !== "input") {
         return Promise.resolve([]);
       }
       const lib = await currentLibrary.get();
-      return lib.getCandidates(state.henkanFeed, state.feed);
+      return lib.getCompletionResult(state.henkanFeed, state.feed);
     },
     async getRanks(): Promise<RankData> {
       const state = currentContext.get().state;

--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -369,7 +369,7 @@ export async function main(denops: Denops) {
       const lib = await currentLibrary.get();
       return Promise.resolve(lib.getRanks(state.henkanFeed));
     },
-    async registerCandidate(kana: unknown, word: unknown) {
+    async registerHenkanResult(kana: unknown, word: unknown) {
       // Note: This method is compatible to completion source
       await denops.dispatcher.completeCallback(kana, word);
     },
@@ -377,7 +377,7 @@ export async function main(denops: Denops) {
       assert(kana, is.String);
       assert(word, is.String);
       const lib = await currentLibrary.get();
-      await lib.registerCandidate("okurinasi", kana, word);
+      await lib.registerHenkanResult("okurinasi", kana, word);
       const context = currentContext.get();
       context.lastCandidate = {
         type: "okurinasi",


### PR DESCRIPTION
`getCandidate()`, `getCandidates()` の役割の違いが一目見て分からないのでリネームしました。