### PR TITLE
Fix Deno KV errors in the latest deno

### DIFF
--- a/denops/skkeleton/sources/deno_kv.ts
+++ b/denops/skkeleton/sources/deno_kv.ts
@@ -126,7 +126,6 @@ export class Dictionary implements BaseDictionary {
           for await (
             const entry of this.#db.list<string[]>({
               prefix: [this.#path, "okurinasi", ...feedPrefix],
-              start: [this.#path, "okurinasi", ...feedPrefix],
             })
           ) {
             candidates.push([entry.key.slice(2).join(""), entry.value]);
@@ -137,7 +136,6 @@ export class Dictionary implements BaseDictionary {
       for await (
         const entry of this.#db.list<string[]>({
           prefix: [this.#path, "okurinasi", ...prefix],
-          start: [this.#path, "okurinasi", ...prefix],
         })
       ) {
         candidates.push([entry.key.slice(2).join(""), entry.value]);


### PR DESCRIPTION
```
% deno --version
deno 1.40.4 (release, x86_64-unknown-linux-gnu)
v8 12.1.285.6
typescript 5.3.3
```

Deno 最新版で補完を使うとエラーが出ていたので修正。

```
[ddc] source: skkeleton "gather()" failed
[ddc] unknown error object
[denops] TypeError: start key is not in the keyspace defined by prefix
[denops]     at KvListIterator.<anonymous> (ext:deno_kv/01_db.ts:141:36)
[denops]     at KvListIterator.next (ext:deno_kv/01_db.ts:579:42)
[denops]     at Dictionary.getCompletionResult (file:///home/shougo/work/skkeleton/denops/skkeleton/sources/deno_kv.ts:138:15)
[denops]     at NumberConvertWrapper.getCompletionResult (file:///home/shougo/work/skkeleton/denops/skkeleton/dictionary.ts:163:42)
[denops]     at Library.getCompletionResult (file:///home/shougo/work/skkeleton/denops/skkeleton/dictionary.ts:248:21)
[denops]     at eventLoopTick (ext:core/01_core.js:65:7)
[denops]     at async Plugin.call (file:///home/shougo/work/denops.vim/denops/@denops-private/service.ts:139:12)
[denops]     at async Service.#dispatch (file:///home/shougo/work/denops.vim/denops/@denops-private/service.ts:69:12)
[denops]     at async Service.dispatch (file:///home/shougo/work/denops.vim/denops/@denops-private/service.ts:74:14)
[denops]     at async Source.gather (file:///home/shougo/work/skkeleton/denops/@ddc-sources/skkeleton.ts:33:25)
```