### PR TITLE
Fix skkeleton.jax

### DIFF
--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -225,7 +225,7 @@ eggLikeNewline                               *skkeleton-config-eggLikeNewline*
 
 globalDictionaries                       *skkeleton-config-globalDictionaries*
         (デフォルト [])
-        複数のグローバル辞書を使用する際に指定するオプションです。
+        グローバル辞書のパスとエンコーディング
         指定する値はグローバル辞書のパスまたは
         パスとエンコーディングからなるタプルの配列になります。
         エンコーディングを指定しない場合は自動判定されます。


### PR DESCRIPTION
ドキュメントの文章をより誤解のない形に書き換えました。
型が配列であることから、複数の辞書を指定できることは自明であるためこのような表記にしました

もとのglobalJisyoの記述は下記の通りであるため、同様の形式としました
```
globalJisyo                                     *skkeleton-config-globalJisyo*
        (デフォルト "/usr/share/skk/SKK-JISYO.L")
        グローバル辞書のパス
        圧縮された辞書をそのまま使う機能はないため
        辞書が圧縮されている場合は展開する必要があります。
        互換性のために残しています。globalDictionariesが指定されていた場合は
        無視されます。
```