### PR TITLE
feat: disable google_japanese_input on affix conversions

### DIFF
--- a/denops/skkeleton/dictionary.ts
+++ b/denops/skkeleton/dictionary.ts
@@ -105,7 +105,10 @@ function convertNumber(pattern: string, entry: string): string {
 }
 
 export interface Dictionary {
-  getHenkanResult(type: HenkanType, word: string): Promise<string[]>;
+  getHenkanResult(
+    word: string,
+    type: HenkanType,
+  ): Promise<string[]>;
   getCompletionResult(prefix: string, feed: string): Promise<CompletionData>;
 }
 
@@ -115,17 +118,20 @@ export type UserDictionaryPath = {
 };
 
 export interface UserDictionary extends Dictionary {
-  getHenkanResult(type: HenkanType, word: string): Promise<string[]>;
+  getHenkanResult(
+    word: string,
+    type: HenkanType,
+  ): Promise<string[]>;
   getCompletionResult(prefix: string, feed: string): Promise<CompletionData>;
   getRanks(prefix: string): RankData;
   purgeCandidate(
-    type: HenkanType,
     word: string,
+    type: HenkanType,
     candidate: string,
   ): Promise<void>;
   registerHenkanResult(
-    type: HenkanType,
     word: string,
+    type: HenkanType,
     candidate: string,
   ): Promise<void>;
   load({ path, rankPath }: UserDictionaryPath): Promise<void>;
@@ -144,13 +150,18 @@ export class NumberConvertWrapper implements Dictionary {
     this.#inner = dict;
   }
 
-  async getHenkanResult(type: HenkanType, word: string): Promise<string[]> {
+  async getHenkanResult(
+    word: string,
+    type: HenkanType,
+  ): Promise<string[]> {
     const realWord = word.replaceAll(/[0-9]+/g, "#");
-    const candidate = await this.#inner.getHenkanResult(type, realWord);
+    const candidate = await this.#inner.getHenkanResult(realWord, type);
     if (word === realWord) {
       return candidate;
     } else {
-      candidate.unshift(...(await this.#inner.getHenkanResult(type, word)));
+      candidate.unshift(
+        ...(await this.#inner.getHenkanResult(word, type)),
+      );
       return candidate.map((c) => convertNumber(c, word));
     }
   }
@@ -213,13 +224,16 @@ export class Library {
     }
   }
 
-  async getHenkanResult(type: HenkanType, word: string): Promise<string[]> {
+  async getHenkanResult(
+    word: string,
+    type: HenkanType,
+  ): Promise<string[]> {
     if (config.immediatelyDictionaryRW) {
       await this.load();
     }
     const merged = new Set<string>();
     for (const dic of this.#dictionaries) {
-      for (const c of await dic.getHenkanResult(type, word)) {
+      for (const c of await dic.getHenkanResult(word, type)) {
         merged.add(c);
       }
     }

--- a/denops/skkeleton/dictionary.ts
+++ b/denops/skkeleton/dictionary.ts
@@ -182,6 +182,8 @@ export function wrapDictionary(dict: Dictionary): Dictionary {
 
 export type HenkanType = "okuriari" | "okurinasi";
 
+export type AffixType = "prefix" | "suffix";
+
 function gatherCandidates(
   collector: Map<string, Set<string>>,
   candidates: [string, string[]][],

--- a/denops/skkeleton/function/henkan.ts
+++ b/denops/skkeleton/function/henkan.ts
@@ -51,7 +51,7 @@ export async function henkanFirst(context: Context, key: string) {
       ? "suffix"
       : undefined;
   }
-  state.candidates = await lib.getHenkanResult(state.mode, word);
+  state.candidates = await lib.getHenkanResult(word, state.mode);
   await henkanForward(context);
 }
 

--- a/denops/skkeleton/sources/deno_kv.ts
+++ b/denops/skkeleton/sources/deno_kv.ts
@@ -3,6 +3,7 @@ import { getKanaTable } from "../kana.ts";
 import { readFileWithEncoding } from "../util.ts";
 import type { CompletionData } from "../types.ts";
 import {
+  AffixType,
   Dictionary as BaseDictionary,
   HenkanType,
   okuriAriMarker,
@@ -105,6 +106,7 @@ export class Dictionary implements BaseDictionary {
   async getHenkanResult(
     word: string,
     type: HenkanType,
+    _affix?: AffixType,
   ): Promise<string[]> {
     const result = await this.#db.get<string[]>([this.#path, type, ...word]);
     return result.value ?? [];

--- a/denops/skkeleton/sources/deno_kv.ts
+++ b/denops/skkeleton/sources/deno_kv.ts
@@ -103,8 +103,8 @@ export class Dictionary implements BaseDictionary {
   }
 
   async getHenkanResult(
-    type: HenkanType,
     word: string,
+    type: HenkanType,
   ): Promise<string[]> {
     const result = await this.#db.get<string[]>([this.#path, type, ...word]);
     return result.value ?? [];

--- a/denops/skkeleton/sources/google_japanese_input.ts
+++ b/denops/skkeleton/sources/google_japanese_input.ts
@@ -19,10 +19,14 @@ export class Dictionary implements BaseDictionary {
   async getHenkanResult(
     word: string,
     _type: HenkanType,
-    _affix?: AffixType,
+    affix?: AffixType,
   ): Promise<string[]> {
-    // It should not work for "okuriari".
-    return _type === "okuriari" ? [] : await this.getMidashis(word);
+    // It should not work for "okuriari" or "affix".
+    return _type === "okuriari"
+      ? []
+      : affix != null
+      ? []
+      : await this.getMidashis(word);
   }
   getCompletionResult(_prefix: string, _feed: string): Promise<CompletionData> {
     // Note: It does not support completions

--- a/denops/skkeleton/sources/google_japanese_input.ts
+++ b/denops/skkeleton/sources/google_japanese_input.ts
@@ -15,7 +15,10 @@ export class Source implements BaseSource {
 
 export class Dictionary implements BaseDictionary {
   async connect() {}
-  async getHenkanResult(_type: HenkanType, word: string): Promise<string[]> {
+  async getHenkanResult(
+    word: string,
+    _type: HenkanType,
+  ): Promise<string[]> {
     // It should not work for "okuriari".
     return _type === "okuriari" ? [] : await this.getMidashis(word);
   }

--- a/denops/skkeleton/sources/google_japanese_input.ts
+++ b/denops/skkeleton/sources/google_japanese_input.ts
@@ -1,5 +1,6 @@
 import { config } from "../config.ts";
 import {
+  AffixType,
   Dictionary as BaseDictionary,
   HenkanType,
   Source as BaseSource,
@@ -18,6 +19,7 @@ export class Dictionary implements BaseDictionary {
   async getHenkanResult(
     word: string,
     _type: HenkanType,
+    _affix?: AffixType,
   ): Promise<string[]> {
     // It should not work for "okuriari".
     return _type === "okuriari" ? [] : await this.getMidashis(word);

--- a/denops/skkeleton/sources/skk_dictionary.ts
+++ b/denops/skkeleton/sources/skk_dictionary.ts
@@ -62,7 +62,10 @@ export class Dictionary implements BaseDictionary {
     this.#cachedCandidates = new Map();
   }
 
-  getHenkanResult(type: HenkanType, word: string): Promise<string[]> {
+  getHenkanResult(
+    word: string,
+    type: HenkanType,
+  ): Promise<string[]> {
     const target = type === "okuriari" ? this.#okuriAri : this.#okuriNasi;
     return Promise.resolve(target.get(word) ?? []);
   }

--- a/denops/skkeleton/sources/skk_dictionary.ts
+++ b/denops/skkeleton/sources/skk_dictionary.ts
@@ -3,6 +3,7 @@ import { getKanaTable } from "../kana.ts";
 import { readFileWithEncoding } from "../util.ts";
 import type { CompletionData } from "../types.ts";
 import {
+  AffixType,
   Dictionary as BaseDictionary,
   HenkanType,
   okuriAriMarker,
@@ -65,6 +66,7 @@ export class Dictionary implements BaseDictionary {
   getHenkanResult(
     word: string,
     type: HenkanType,
+    _affix?: AffixType,
   ): Promise<string[]> {
     const target = type === "okuriari" ? this.#okuriAri : this.#okuriNasi;
     return Promise.resolve(target.get(word) ?? []);

--- a/denops/skkeleton/sources/skk_server.ts
+++ b/denops/skkeleton/sources/skk_server.ts
@@ -81,7 +81,10 @@ export class Dictionary implements BaseDictionary {
     };
   }
 
-  async getHenkanResult(_type: HenkanType, word: string): Promise<string[]> {
+  async getHenkanResult(
+    word: string,
+    _type: HenkanType,
+  ): Promise<string[]> {
     await this.connect();
 
     if (this.#server == null) return [];
@@ -118,7 +121,7 @@ export class Dictionary implements BaseDictionary {
     for (const midashi of midashis) {
       candidates.push([
         midashi,
-        await this.getHenkanResult("okurinasi", midashi),
+        await this.getHenkanResult(midashi, "okurinasi"),
       ]);
     }
 

--- a/denops/skkeleton/sources/skk_server.ts
+++ b/denops/skkeleton/sources/skk_server.ts
@@ -4,6 +4,7 @@ import { Encode } from "../types.ts";
 import { getKanaTable } from "../kana.ts";
 import { TextLineStream } from "../deps/std/streams.ts";
 import {
+  AffixType,
   Dictionary as BaseDictionary,
   HenkanType,
   Source as BaseSource,
@@ -84,6 +85,7 @@ export class Dictionary implements BaseDictionary {
   async getHenkanResult(
     word: string,
     _type: HenkanType,
+    _affix?: AffixType,
   ): Promise<string[]> {
     await this.connect();
 
@@ -121,7 +123,7 @@ export class Dictionary implements BaseDictionary {
     for (const midashi of midashis) {
       candidates.push([
         midashi,
-        await this.getHenkanResult(midashi, "okurinasi"),
+        await this.getHenkanResult(midashi, "okurinasi", undefined),
       ]);
     }
 

--- a/denops/skkeleton/sources/user_dictionary.ts
+++ b/denops/skkeleton/sources/user_dictionary.ts
@@ -60,7 +60,10 @@ export class Dictionary implements UserDictionary {
     this.#rank = rank ?? new Map();
   }
 
-  getHenkanResult(type: HenkanType, word: string): Promise<string[]> {
+  getHenkanResult(
+    word: string,
+    type: HenkanType,
+  ): Promise<string[]> {
     const target = type === "okuriari" ? this.#okuriAri : this.#okuriNasi;
     return Promise.resolve(target.get(word) ?? []);
   }

--- a/denops/skkeleton/sources/user_dictionary.ts
+++ b/denops/skkeleton/sources/user_dictionary.ts
@@ -2,6 +2,7 @@ import { config } from "../config.ts";
 import { getKanaTable } from "../kana.ts";
 import type { CompletionData, RankData } from "../types.ts";
 import {
+  AffixType,
   Dictionary as BaseDictionary,
   HenkanType,
   okuriAriMarker,
@@ -63,6 +64,7 @@ export class Dictionary implements UserDictionary {
   getHenkanResult(
     word: string,
     type: HenkanType,
+    _affix?: AffixType,
   ): Promise<string[]> {
     const target = type === "okuriari" ? this.#okuriAri : this.#okuriNasi;
     return Promise.resolve(target.get(word) ?? []);

--- a/denops/skkeleton/state.ts
+++ b/denops/skkeleton/state.ts
@@ -1,6 +1,6 @@
 import { modifyCandidate } from "./candidate.ts";
 import { config } from "./config.ts";
-import type { HenkanType } from "./dictionary.ts";
+import type { AffixType, HenkanType } from "./dictionary.ts";
 import { getKanaTable } from "./kana.ts";
 import { KanaTable } from "./kana/type.ts";
 import { Cell } from "./util.ts";
@@ -8,8 +8,6 @@ import { Cell } from "./util.ts";
 export type State = InputState | HenkanState | EscapeState;
 
 export type InputMode = "direct" | HenkanType;
-
-export type AffixType = "prefix" | "suffix";
 
 export type InputState = {
   type: "input";


### PR DESCRIPTION
In the current implementation, the `google_japanse_input` source returns invalid candidates for affixes (prefix and suffix).

For example, `Dai>` gives `第＞` and `大＞`.

This PR prevents it by conditionally disabling the `google_japanse_input` source.

In order to implement the feature, I changed the signature of `getHenkanResult()` and related methods.

``` diff
- getHenkanResult(type: HenkanType, word: string)
+ getHenkanResult(word: string, type: HenkanType, affix?: AffixType)
```

Let me know if reviewer prefers `type, word, affix` or some other signatures.