### PR TITLE
encoding-japanese の import を修正

### DIFF
--- a/denops/skkeleton/util.ts
+++ b/denops/skkeleton/util.ts
@@ -1,5 +1,5 @@
 import { Denops, fn, op } from "./deps.ts";
-import * as encoding from "npm:encoding-japanese@2.2.0";
+import encoding from "npm:encoding-japanese@2.2.0";
 
 import { basename } from "jsr:@std/path@~1.0.3/basename";
 import { parse } from "jsr:@std/path@~1.0.3/parse";


### PR DESCRIPTION
Close #204 

`npm:encoding-japanese@2.2.0` を `import * as` で読み込んでいるのが原因のようだったので修正しました。