### PR TITLE
送りあり変換の補完ソースを追加

### DIFF
--- a/denops/@ddc-sources/skkeleton/okurisplits.ts
+++ b/denops/@ddc-sources/skkeleton/okurisplits.ts
@@ -1,0 +1,8 @@
+export function okuriSplits(text: string): [string, string][] {
+  if (text === "") {
+    return [];
+  }
+  const a = [...text];
+  const r = Array.from(Array(a.length - 1), (_, i) => a.length - 1 - i);
+  return r.map((i) => [a.slice(0, i).join(""), a.slice(i).join("")]);
+}

--- a/denops/@ddc-sources/skkeleton/okurisplits_test.ts
+++ b/denops/@ddc-sources/skkeleton/okurisplits_test.ts
@@ -1,0 +1,16 @@
+import { assertEquals } from "jsr:@std/assert@~1.0.3/equals";
+import { okuriSplits } from "./okurisplits.ts";
+
+Deno.test({
+  name: "split",
+  fn() {
+    const expect = [
+      ["ばりか", "た"],
+      ["ばり", "かた"],
+      ["ば", "りかた"],
+    ];
+    assertEquals(okuriSplits("ばりかた"), expect);
+    assertEquals(okuriSplits("あ"), []);
+    assertEquals(okuriSplits(""), []);
+  },
+});

--- a/denops/@ddc-sources/skkeleton_okuri.ts
+++ b/denops/@ddc-sources/skkeleton_okuri.ts
@@ -1,0 +1,88 @@
+import {
+  BaseSource,
+  type GatherArguments,
+  type GetCompletePositionArguments,
+  type OnCompleteDoneArguments,
+} from "../skkeleton/deps/ddc/source.ts";
+import { type Item } from "../skkeleton/deps/ddc/types.ts";
+import { getOkuriStr } from "../skkeleton/okuri.ts";
+import { okuriSplits } from "./skkeleton/okurisplits.ts";
+
+type Never = Record<PropertyKey, never>;
+
+type CompletionMetadata = {
+  skkeleton: {
+    midasi: string;
+    word: string;
+  };
+};
+
+export class Source extends BaseSource<Never> {
+  override async getCompletePosition(
+    args: GetCompletePositionArguments<Never>,
+  ): Promise<number> {
+    const preEditLength = await args.denops.dispatch(
+      "skkeleton",
+      "getPreEditLength",
+    ).catch(() => 0) as number;
+    if (preEditLength != 0) {
+      return args.context.input.length - preEditLength;
+    }
+    return -1;
+  }
+
+  override async gather(
+    args: GatherArguments<Never>,
+  ): Promise<Item<CompletionMetadata>[]> {
+    const kana = String(
+      await args.denops.dispatch(
+        "skkeleton",
+        "getPrefix",
+      ),
+    );
+
+    const chunks = okuriSplits(kana ?? "");
+    const candidates: Item<CompletionMetadata>[] = [];
+    for (const [word, okuri] of chunks) {
+      const midasi = getOkuriStr(word, okuri);
+      const cands = await args.denops.dispatch(
+        "skkeleton",
+        "getCandidates",
+        midasi,
+        "okuriari",
+      ) as string[] | undefined;
+      if (cands == null) {
+        continue;
+      }
+      for (const cand of cands) {
+        const candStrip = cand.replace(/;.*$/, "");
+        candidates.push({
+          word: candStrip + okuri,
+          user_data: {
+            skkeleton: {
+              midasi,
+              word: cand,
+            },
+          },
+        });
+      }
+    }
+    return candidates;
+  }
+
+  override async onCompleteDone(
+    args: OnCompleteDoneArguments<Never, CompletionMetadata>,
+  ) {
+    await args.denops.dispatch(
+      "skkeleton",
+      "completeCallback",
+      args.userData.skkeleton.midasi,
+      args.userData.skkeleton.word,
+      "okuriari",
+    );
+  }
+
+  override params(): Never {
+    return {};
+  }
+}

--- a/denops/skkeleton/dictionary.ts
+++ b/denops/skkeleton/dictionary.ts
@@ -3,8 +3,9 @@ import type { CompletionData, RankData } from "./types.ts";
 import { number2kanji } from "npm:@geolonia/japanese-numeral@1.0.2";
 import { convertNumberToRoman } from "npm:cr-numeral@1.1.3";
 
-import { toFileUrl } from "jsr:@std/path@~1.0.3/to-file-url";
+import { is, Predicate } from "jsr:@core/unknownutil@~4.3.0";
 import { zip } from "jsr:@std/collections@~1.0.5/zip";
+import { toFileUrl } from "jsr:@std/path@~1.0.3/to-file-url";
 
 export const okuriAriMarker = ";; okuri-ari entries.";
 export const okuriNasiMarker = ";; okuri-nasi entries.";
@@ -182,6 +183,10 @@ export function wrapDictionary(dict: Dictionary): Dictionary {
 }
 
 export type HenkanType = "okuriari" | "okurinasi";
+
+export const isHenkanType = is.LiteralOneOf(
+  ["okurinasi", "okuriari"] as const,
+) satisfies Predicate<HenkanType>;
 
 function gatherCandidates(
   collector: Map<string, Set<string>>,

--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -2,7 +2,7 @@ import { config, setConfig } from "./config.ts";
 import { autocmd, Denops, Entrypoint, fn, vars } from "./deps.ts";
 import { functions, modeFunctions } from "./function.ts";
 import { disable as disableFunc } from "./function/disable.ts";
-import { load as loadDictionary } from "./dictionary.ts";
+import { isHenkanType, load as loadDictionary } from "./dictionary.ts";
 import { Dictionary as DenoKvDictionary } from "./sources/deno_kv.ts";
 import { currentKanaTable, registerKanaTable } from "./kana.ts";
 import { handleKey, registerKeyMap } from "./keymap.ts";
@@ -311,19 +311,24 @@ export const main: Entrypoint = async (denops) => {
       const lib = await currentLibrary.get();
       return Promise.resolve(lib.getRanks(state.henkanFeed));
     },
-    async registerHenkanResult(kana: unknown, word: unknown) {
+    async registerHenkanResult(midasi: unknown, word: unknown) {
       // Note: This method is compatible to completion source
-      await denops.dispatcher.completeCallback(kana, word);
+      await denops.dispatcher.completeCallback(midasi, word);
     },
-    async completeCallback(kana: unknown, word: unknown) {
-      assert(kana, is.String);
+    async completeCallback(
+      midasi: unknown,
+      word: unknown,
+      type: unknown = "okurinasi",
+    ) {
+      assert(midasi, is.String);
       assert(word, is.String);
+      assert(type, isHenkanType);
       const lib = await currentLibrary.get();
-      await lib.registerHenkanResult("okurinasi", kana, word);
+      await lib.registerHenkanResult(type, midasi, word);
       const context = currentContext.get();
       context.lastCandidate = {
-        type: "okurinasi",
-        word: kana,
+        type,
+        word: midasi,
         candidate: word,
       };
     },

--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -295,6 +295,12 @@ export const main: Entrypoint = async (denops) => {
       }
       return Promise.resolve(state.henkanFeed);
     },
+    async getCandidates(kana: unknown, type: unknown = "okurinasi") {
+      assert(kana, is.String);
+      assert(type, isHenkanType);
+      const lib = await currentLibrary.get();
+      return await lib.getHenkanResult(type, kana);
+    },
     async getCompletionResult(): Promise<CompletionData> {
       const state = currentContext.get().state;
       if (state.type !== "input") {

--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -474,7 +474,7 @@ COMPLETION                                              *skkeleton-completion*
         \     'sorters': ['sorter_rank']
         \   },
         \   'skkeleton': {
-        \     'mark': 'SKK'
+        \     'mark': 'SKK',
         \     'matchers': [],
         \     'sorters': [],
         \     'converters': [],
@@ -482,7 +482,7 @@ COMPLETION                                              *skkeleton-completion*
         \     'minAutoCompleteLength': 1,
         \   },
         \   'skkeleton_okuri': {
-        \     'mark': 'SKK*'
+        \     'mark': 'SKK*',
         \     'matchers': [],
         \     'sorters': [],
         \     'converters': [],

--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -453,29 +453,40 @@ g:skkeleton#mapped_keys
 COMPLETION                                              *skkeleton-completion*
 
     |ddc| と連携した補完環境を提供します。
-    送りなし変換の仮名入力時に動作し、入力された仮名で始まる候補を表示します。
+    送りなし変換の仮名入力時に動作し、入力された仮名(見出し)で始まる候補を
+    直接変換する `skkeleton` ソース及び、見出しの一部を送り仮名に見立てて
+    送りあり変換する(「あたり」の場合、「あた+り」=>「辺り」や
+    「あ*たり」=>「当たり」など) `skkeleton_okuri` ソースを用意しています。
     候補の順番は |skkeleton-config-completionRankFile| で指定したファイルに
     保存できます。
     ソース側で計算を行う特殊な仕様になっているため
-    |ddc-source-option-matchers|等を空にした上で
+    |ddc-source-option-matchers| 等を空にした上で
     |ddc-source-option-isVolatile| を指定し毎回計算が走るようにしています。
-    また、1文字だけ入力した際に、完全一致する候補だけを表示する機能を用意して
-    いるので、 |ddc-source-option-minAutoCompleteLength| を1に変更しています。
+    また、`skkeleton` ソースには1文字だけ入力した際に、完全一致する候補だけを
+    表示する機能を用意しているので、|ddc-source-option-minAutoCompleteLength|
+    を1に変更しています。
 >vim
     " 例
-    call ddc#custom#patch_global('sources', ['skkeleton'])
+    call ddc#custom#patch_global('sources', ['skkeleton', 'skkeleton_okuri'])
     call ddc#custom#patch_global('sourceOptions', {
         \   '_': {
         \     'matchers': ['matcher_head'],
         \     'sorters': ['sorter_rank']
         \   },
         \   'skkeleton': {
-        \     'mark': 'skkeleton',
+        \     'mark': 'SKK'
         \     'matchers': [],
         \     'sorters': [],
         \     'converters': [],
         \     'isVolatile': v:true,
         \     'minAutoCompleteLength': 1,
+        \   },
+        \   'skkeleton_okuri': {
+        \     'mark': 'SKK*'
+        \     'matchers': [],
+        \     'sorters': [],
+        \     'converters': [],
+        \     'isVolatile': v:true,
         \   },
         \ })
     call skkeleton#config({'completionRankFile': '~/.skkeleton/rank.json'})


### PR DESCRIPTION
例えば「あたり」の場合、「あた+り」=>「辺り」や「あ*たり」=>「当たり」などの候補を出力するような補完ソースを追加します