### PR TITLE
Add skkeleton#register_kanatable_file()

### DIFF
--- a/autoload/skkeleton.vim
+++ b/autoload/skkeleton.vim
@@ -142,9 +142,12 @@ function! skkeleton#register_keymap(state, key, func_name)
   call skkeleton#request_async('registerKeyMap', [a:state, key, a:func_name])
 endfunction
 
-function! skkeleton#register_kanatable(table_name, table, ...) abort
-  let create = get(a:000, 0, v:false)
-  call skkeleton#request_async('registerKanaTable', [a:table_name, a:table, create])
+function! skkeleton#register_kanatable(table_name, table, create=v:false) abort
+  call skkeleton#request_async('registerKanaTable', [a:table_name, a:table, a:create])
+endfunction
+
+function! skkeleton#register_kanatable_file(table_name, path, encoding='', create=v:false) abort
+  call skkeleton#request_async('registerKanaTableFile', [a:table_name, a:path, a:encoding, a:create])
 endfunction
 
 " return [complete_type, complete_info]

--- a/denops/skkeleton/kana.ts
+++ b/denops/skkeleton/kana.ts
@@ -87,6 +87,30 @@ export async function loadKanaTableFiles(
   injectKanaTable("rom", table);
 }
 
+export async function loadKanaTableFile(
+  tableName: string,
+  path: string,
+  encoding: string,
+  create: boolean,
+): Promise<void> {
+  const table: KanaTable = [];
+
+  const file = await readFileWithEncoding(path, encoding);
+  const lines = file.split("\n");
+  for (const line of lines) {
+    if (line.startsWith("#")) {
+      continue;
+    }
+    if (line.trim() === "") {
+      continue;
+    }
+    const [from, result] = line.split(",");
+    table.push([from, [result, ""]]);
+  }
+
+  injectKanaTable(tableName, table, create);
+}
+
 /*
  * Concat given kanaTable to the table named `name`.
  * When the table is not found, create if create=true; otherwise throws `table ${name} is not found`.

--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -3,7 +3,7 @@ import { functions, modeFunctions } from "./function.ts";
 import { disable as disableFunc } from "./function/disable.ts";
 import { isHenkanType, load as loadDictionary } from "./dictionary.ts";
 import { Dictionary as DenoKvDictionary } from "./sources/deno_kv.ts";
-import { currentKanaTable, registerKanaTable } from "./kana.ts";
+import { currentKanaTable, registerKanaTable, loadKanaTableFile } from "./kana.ts";
 import { handleKey, registerKeyMap } from "./keymap.ts";
 import { initializeStateWithAbbrev } from "./mode.ts";
 import { keyToNotation, notationToKey, receiveNotation } from "./notation.ts";
@@ -253,6 +253,13 @@ export const main: Entrypoint = async (denops) => {
     registerKanaTable(tableName: unknown, table: unknown, create: unknown) {
       assert(tableName, is.String);
       registerKanaTable(tableName, table, !!create);
+      return Promise.resolve();
+    },
+    async registerKanaTableFile(tableName: unknown, path: unknown, encoding: unknown, create: unknown) {
+      assert(tableName, is.String);
+      assert(path, is.String);
+      assert(encoding, is.String);
+      await loadKanaTableFile(tableName, path, encoding, create);
       return Promise.resolve();
     },
     async handle(

--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -3,7 +3,11 @@ import { functions, modeFunctions } from "./function.ts";
 import { disable as disableFunc } from "./function/disable.ts";
 import { isHenkanType, load as loadDictionary } from "./dictionary.ts";
 import { Dictionary as DenoKvDictionary } from "./sources/deno_kv.ts";
-import { currentKanaTable, registerKanaTable, loadKanaTableFile } from "./kana.ts";
+import {
+  currentKanaTable,
+  loadKanaTableFile,
+  registerKanaTable,
+} from "./kana.ts";
 import { handleKey, registerKeyMap } from "./keymap.ts";
 import { initializeStateWithAbbrev } from "./mode.ts";
 import { keyToNotation, notationToKey, receiveNotation } from "./notation.ts";
@@ -255,7 +259,12 @@ export const main: Entrypoint = async (denops) => {
       registerKanaTable(tableName, table, !!create);
       return Promise.resolve();
     },
-    async registerKanaTableFile(tableName: unknown, path: unknown, encoding: unknown, create: unknown) {
+    async registerKanaTableFile(
+      tableName: unknown,
+      path: unknown,
+      encoding: unknown,
+      create: unknown,
+    ) {
       assert(tableName, is.String);
       assert(path, is.String);
       assert(encoding, is.String);

--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -268,7 +268,7 @@ export const main: Entrypoint = async (denops) => {
       assert(tableName, is.String);
       assert(path, is.String);
       assert(encoding, is.String);
-      await loadKanaTableFile(tableName, path, encoding, create);
+      await loadKanaTableFile(tableName, path, encoding, !!create);
       return Promise.resolve();
     },
     async handle(

--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -447,6 +447,15 @@ skkeleton#register_kanatable({tableName}, {table} [, {create}])
           \   'lyo': ['ょ'],
           \ })
 <
+
+                                         *skkeleton#register_kanatable_file()*
+skkeleton#register_kanatable_file({tableName}, {path} [, {encoding}[, {create}]])
+        仮名入力のテーブルを登録できます。
+        {tableName}で指定したテーブルに{path}で指定した辞書の定義が登録されま
+        す。{create}が指定されていない場合は存在しないテーブル名を指定すると
+        エラーになります。
+        {encoding}を指定しない場合は自動判定されます。
+
                                                  *skkeleton#register_keymap()*
 skkeleton#register_keymap({state}, {key}, {funcName})
         ステート単位のキーマップを定義します。


### PR DESCRIPTION
#216 

`skkeleton#register_kanatable_file()` を実装してみました。こんな仕様だとどうでしょうか。

`globalKanaTableFiles` は削除してよいと思っていますが、それはやっていません