### PR TITLE
fix: unwanted disable when `i_CTRL-O`

### DIFF
--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -77,14 +77,15 @@ async function init(denops: Denops) {
     helper.remove("*");
     // Note: 使い終わったステートを初期化する
     //       CmdlineEnterにしてしまうと辞書登録時の呼び出しで壊れる
+    //       挿入モードの`<C-o>`(niI)などで解除されると困るのでModeChangedの:nにしておく
     helper.define(
-      ["InsertLeave", "CmdlineLeave"],
-      "*",
+      ["ModeChanged"],
+      "*:n",
       `call denops#request('${denops.name}', 'reset', [])`,
     );
     helper.define(
-      ["InsertLeave", "CmdlineLeave"],
-      "*",
+      ["ModeChanged"],
+      "*:n",
       `call skkeleton#disable()`,
     );
   });


### PR DESCRIPTION
[i_CTRL_O](https://vim-jp.org/vimdoc-ja/insert.html#i_CTRL-O) で挿入モードを一時的に抜けた際などに解除されてしまう問題への対処