### PR TITLE
Feat: make henkanFirst available for use in the keymap

### DIFF
--- a/denops/skkeleton/kana/rom_hira.ts
+++ b/denops/skkeleton/kana/rom_hira.ts
@@ -1,12 +1,10 @@
 import { disable } from "../function/disable.ts";
-import { henkanFirst } from "../function/henkan.ts";
 import { henkanPoint } from "../function/input.ts";
 import { abbrev, zenkaku } from "../function/mode.ts";
 import { katakana } from "../function/mode.ts";
 import type { KanaTable } from "./type.ts";
 
 export const romToHira: KanaTable = [
-  [" ", henkanFirst],
   ["!", ["！", ""]],
   [",", ["、", ""]],
   ["-", ["ー", ""]],

--- a/denops/skkeleton/keymap.ts
+++ b/denops/skkeleton/keymap.ts
@@ -10,6 +10,7 @@ import {
 import { escape } from "./function/disable.ts";
 import {
   henkanBackward,
+  henkanFirst,
   henkanForward,
   henkanInput,
   suffix,
@@ -32,6 +33,7 @@ const input: KeyMap = {
     "<cr>": newline,
     "<esc>": escape,
     "<nl>": kakuteiKey,
+    "<space>": henkanFirst,
     "<c-q>": hankatakana,
     ">": prefix,
   },

--- a/doc/skkeleton-functions.jax
+++ b/doc/skkeleton-functions.jax
@@ -32,7 +32,7 @@ escape                                            *skkeleton-functions-escape*
         再びモードに入った際にskkeletonが有効化されます。
 
 henkanFirst                                  *skkeleton-functions-henkanFirst*
-        (input)!
+        (input: <Space>)!
         変換を開始します。
         直接入力モードの場合は何もマッピングされていないように振る舞います。
 

--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -129,6 +129,7 @@ input:
         <CR>      : |skkeleton-functions-newline|
         <Esc>     : |skkeleton-functions-escape|
         <NL>      : |skkeleton-functions-kakutei|
+        <Space>   : |skkeleton-functions-henkanFirst|
 henkan:
         <C-g>     : |skkeleton-functions-cancel|
         <CR>      : |skkeleton-functions-newline|


### PR DESCRIPTION
#183 に関連
変換キーを keymap に移動しました。また、`henkanPoint` が設定されていない場合、 `henkanFirst` が `kanaInput` を呼び出すように変更しました。

## 動作例
上部に記載されているのはvimrcの設定例です。

![demo_loop](https://github.com/user-attachments/assets/298a4a50-b267-44d6-95db-374e98116424)