### PR TITLE
feat: fallback to kanaInput at henkanFirst 

### DIFF
--- a/denops/skkeleton/function/henkan_test.ts
+++ b/denops/skkeleton/function/henkan_test.ts
@@ -1,5 +1,7 @@
 import { Context } from "../context.ts";
+import { InputState } from "../state.ts";
 import { currentLibrary } from "../store.ts";
+import { henkanFirst } from "./henkan.ts";
 import { dispatch } from "./testutil.ts";
 
 import { assertEquals } from "jsr:@std/assert@~1.0.3/equals";
@@ -62,5 +64,20 @@ Deno.test({
     const context = new Context();
     await dispatch(context, ";henkan x");
     assertEquals(context.toString(), "▽へんかん");
+  },
+});
+
+Deno.test({
+  name: "fallback to kanaInput in henkanFirst",
+  async fn() {
+    const context = new Context();
+    (context.state as InputState).table = [[" ", ["", "space"]]];
+    await dispatch(context, " ");
+    assertEquals(context.toString(), "space");
+    // avoid infinite recursion
+    // fallback to direct input
+    (context.state as InputState).table = [[" ", henkanFirst]];
+    await dispatch(context, " ");
+    assertEquals(context.preEdit.output(""), " ");
   },
 });

--- a/doc/skkeleton-functions.jax
+++ b/doc/skkeleton-functions.jax
@@ -34,7 +34,9 @@ escape                                            *skkeleton-functions-escape*
 henkanFirst                                  *skkeleton-functions-henkanFirst*
         (input)!
         変換を開始します。
-        直接入力モードの場合は何もマッピングされていないように振る舞います。
+        直接入力モードの場合は仮名テーブルの処理を行います。
+        該当のテーブルに `henkanFirst` が割り当てられている場合は何もマッピング
+        されていないように振る舞います。
 
 henkanForward                              *skkeleton-functions-henkanForward*
         (henkan: <Space>)


### PR DESCRIPTION
#183 に対応するために `henkanFirst` 内で直接入力の代わりに `kanaInput` を呼び出すように変更