### PR TITLE
fix: abbrevモードでのキャンセル後にモードをhiraに戻す

### DIFF
--- a/denops/skkeleton/function/common.ts
+++ b/denops/skkeleton/function/common.ts
@@ -73,7 +73,7 @@ export async function newline(context: Context) {
   }
 }
 
-export function cancel(context: Context) {
+export async function cancel(context: Context) {
   const state = context.state;
   if (
     state.type === "input" &&
@@ -83,12 +83,12 @@ export function cancel(context: Context) {
     context.kakutei("\x03");
   }
   if (config.immediatelyCancel) {
-    initializeState(context.state);
+    await initializeStateWithAbbrev(context);
     return;
   }
   switch (state.type) {
     case "input":
-      initializeState(state);
+      await initializeStateWithAbbrev(context);
       break;
     case "henkan":
       context.state.type = "input";


### PR DESCRIPTION
## 問題

`cancel()`（`<C-g>`キー）が`initializeState()`を直接呼んでいたため、`state.mode`は`"direct"`にリセットされますが`modeChange()`は呼ばれません。

その結果、abbrevモードで`<C-g>`キャンセルした後も`context.mode`および`vim.g["skkeleton#mode"]`が`"abbrev"`のまま残るバグがありました。

## 修正

`initializeStateWithAbbrev()`を使うよう変更することで、abbrevモードから抜ける際に`modeChange("hira")`が呼ばれ、表示上のモードが正しく同期されます。

これは`kakutei()`が既に`initializeStateWithAbbrev()`を使っているのと同じ対応です。