### PR TITLE
feat: direct入力状態からabbrevモードを一時的に使うabbrevFromDirect APIを追加

### DIFF
--- a/denops/skkeleton/context.ts
+++ b/denops/skkeleton/context.ts
@@ -24,6 +24,8 @@ export class Context {
     word: "",
     candidate: "",
   };
+  // abbrevFromDirect用: abbrevセッション完了時に呼ばれるコールバック
+  onAbbrevDone?: () => Promise<void>;
 
   kakutei(str: string) {
     this.preEdit.doKakutei(str);

--- a/denops/skkeleton/function/common.ts
+++ b/denops/skkeleton/function/common.ts
@@ -73,7 +73,7 @@ export async function newline(context: Context) {
   }
 }
 
-export function cancel(context: Context) {
+export async function cancel(context: Context) {
   const state = context.state;
   if (
     state.type === "input" &&
@@ -83,12 +83,12 @@ export function cancel(context: Context) {
     context.kakutei("\x03");
   }
   if (config.immediatelyCancel) {
-    initializeState(context.state);
+    await initializeStateWithAbbrev(context);
     return;
   }
   switch (state.type) {
     case "input":
-      initializeState(state);
+      await initializeStateWithAbbrev(context);
       break;
     case "henkan":
       context.state.type = "input";

--- a/denops/skkeleton/function/henkan.ts
+++ b/denops/skkeleton/function/henkan.ts
@@ -135,8 +135,13 @@ export async function henkanInput(context: Context, key: string) {
     }
   }
 
+  const wasAbbrevSession = context.onAbbrevDone !== undefined;
   await kakutei(context);
-  await handleKey(context, keyToNotation[key] ?? key);
+  if (wasAbbrevSession) {
+    context.kakutei(key);
+  } else {
+    await handleKey(context, keyToNotation[key] ?? key);
+  }
 }
 
 export async function suffix(context: Context) {

--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -144,6 +144,19 @@ async function enable(opts: unknown, vimStatus: unknown): Promise<string> {
   return "";
 }
 
+async function abbrevFromDirect(
+  opts: unknown,
+  vimStatus: unknown,
+): Promise<string> {
+  await enable(opts, vimStatus);
+  const context = currentContext.get();
+  context.onAbbrevDone = async () => {
+    await context.denops!.call("skkeleton#disable");
+  };
+  await modeFunctions.get()["abbrev"]?.(context, "");
+  return context.preEdit.output(context.toString());
+}
+
 async function disable(opts: unknown, vimStatus: unknown): Promise<string> {
   const context = currentContext.get();
   const state = currentContext.get().state;
@@ -303,6 +316,8 @@ export const main: Entrypoint = async (denops) => {
         return buildResult(await enable(opts, vimStatus));
       } else if (func === "enable") {
         return buildResult(await enable(opts, vimStatus));
+      } else if (func === "abbrevFromDirect") {
+        return buildResult(await abbrevFromDirect(opts, vimStatus));
       } else if (func === "disable") {
         return buildResult(await disable(opts, vimStatus));
       } else if (func === "toggle") {
@@ -374,6 +389,10 @@ export const main: Entrypoint = async (denops) => {
         word: midasi,
         candidate: word,
       };
+      // abbrevFromDirectセッション中にddc経由で確定された場合の後処理
+      if (context.onAbbrevDone && context.mode === "abbrev") {
+        await initializeStateWithAbbrev(context, ["converter"]);
+      }
     },
     // deno-lint-ignore require-await
     async getConfig() {

--- a/denops/skkeleton/mode.ts
+++ b/denops/skkeleton/mode.ts
@@ -29,8 +29,18 @@ export async function initializeStateWithAbbrev(
   ignore: string[] = [],
 ) {
   if (context.mode === "abbrev") {
-    await modeChange(context, "hira");
     ignore = ignore.filter((key) => key !== "converter" && key !== "table");
+    initializeState(context.state, ignore);
+    if (context.onAbbrevDone) {
+      // onAbbrevDoneがある場合はmodeChange("hira")をスキップし
+      // コールバックに後処理を委ねる（例: disable）
+      const callback = context.onAbbrevDone;
+      context.onAbbrevDone = undefined;
+      await callback();
+    } else {
+      await modeChange(context, "hira");
+    }
+    return;
   }
   initializeState(context.state, ignore);
 }


### PR DESCRIPTION
## 概要

skkeleton無効（direct入力）状態から直接abbrevモードに入り、変換確定またはキャンセル後に自動的にdisableに戻る`abbrevFromDirect` APIを追加します。

## 使用例

```lua
vim.keymap.set({ "i", "c", "t" }, "<C-/>", function()
  if not vim.fn["skkeleton#is_enabled"]() then
    vim.fn["skkeleton#handle"]("abbrevFromDirect", vim.empty_dict())
  end
end)
```

## 実装内容

- **`Context.onAbbrevDone`**: abbrevセッション完了時のコールバックフィールドを追加。循環依存を避けながらdisable処理を委ねるために使用
- **`initializeStateWithAbbrev()`**: `onAbbrevDone`がある場合は`modeChange("hira")`をスキップしてコールバックを実行（hiraへの一瞬の遷移を防ぐ）
- **`abbrevFromDirect()`**: enableしてからabbrevモードに入り、`onAbbrevDone`に`skkeleton#disable`を設定
- **`completeCallback()`**: ddc経由（`<C-y>`など）で確定した場合も`onAbbrevDone`を処理（`<C-y>`はskkeletonのmapped_keysに含まれないため必要）
- **`henkanInput()`**: abbrevFromDirectセッション中に変換候補を確定させるキーを入力した際、`handleKey`経由でkanaテーブルに通さず直接出力する。`kakutei`内で`onAbbrevDone`（`skkeleton#disable`）が呼ばれた後にキーがkana変換されてしまう問題を修正

## 依存

このPRはfix #242（`cancel()`のバグフィックス）に依存しています。