### PR TITLE
fix: registerWord後に元のcontextを復元する

### DIFF
--- a/denops/skkeleton/function/dictionary.ts
+++ b/denops/skkeleton/function/dictionary.ts
@@ -38,6 +38,7 @@ export async function registerWord(context: Context): Promise<boolean> {
       once: true,
     });
     const input = await fn.input(denops, base + okuri + ": ");
+    currentContext.set(context);
     if (input === "" || input.includes("__skkeleton_return__")) {
       await denops.cmd("echo '' | redraw");
       return false;


### PR DESCRIPTION
## 問題

`registerWord()` は、コマンドラインモード中にも skkeleton が動作できるよう、`currentContext.init()` で新しい context を作成しています。

しかし、この処理によって **グローバルな current context が `mode="hira"` の新しい context で恒久的に置き換えられてしまいます**。

その結果、登録ダイアログ（辞書登録 or キャンセル問わず）の後、すべてのキー入力が新しい context で処理されてしまい、ユーザーが変換前に使っていたモード（kata, hankata など）が失われます。

## 再現手順

1. katakana モード（またはその他の非 hira モード）で変換を開始する
2. 候補をすべて使い切るまで `space` を押して登録ダイアログを表示させる
3. ダイアログをキャンセルする
4. 次の文字を入力する → 期待: katakana モード / 実際: hira モード

## 修正内容

`fn.input()` の呼び出しの後に `currentContext.set(context)` を追加し、元の context を復元するようにしました。

`currentContext.init()` による新しい context の作成自体は、コマンドライン中の skkeleton 動作のために必要なため、変更していません。

## 影響範囲

この修正により、`registerWord` 完了後に元のモード（kata, hankata など）が保持されるようになります。

---

🤖 Co-authored with [Claude Code](https://claude.com/claude-code)