### PR TITLE
skkserv へのリクエストを直列化して応答の取り違いを防ぐ

### DIFF
--- a/denops/skkeleton/config.ts
+++ b/denops/skkeleton/config.ts
@@ -33,6 +33,7 @@ export const config: Omit<ConfigOptions, "globalDictionaries"> & {
   skkServerPort: 1178,
   skkServerReqEnc: "euc-jp",
   skkServerResEnc: "euc-jp",
+  skkServerTimeout: 5000,
   sources: ["skk_dictionary"],
   userDictionary: "~/.skkeleton",
 };
@@ -111,6 +112,7 @@ const validators: Validators = {
   skkServerPort: (x) => ensure(x, is.Number),
   skkServerReqEnc: ensureEncoding,
   skkServerResEnc: ensureEncoding,
+  skkServerTimeout: (x) => ensure(x, is.Number),
   sources: (x) => ensure(x, is.ArrayOf(is.String)),
   useGoogleJapaneseInput: () => {
     throw '`useGoogleJapaneseInput` is removed. Please use `sources` with "google_japanese_input"';

--- a/denops/skkeleton/sources/skk_server.ts
+++ b/denops/skkeleton/sources/skk_server.ts
@@ -41,8 +41,20 @@ export class Source implements BaseSource {
   }
 }
 
+// 1 回のリクエスト/レスポンスの往復にこの時間だけ猶予を与え、超えたら諦めて空で解決
+// する。応答が 1 つ失われても、下の直列化したキューがデッドロックしないようにするため。
+// skkserv の応答は通常ほぼ即座に返るが、ネットワーク上の skkserv が遅い辞書引きへ
+// フォールバックする場合が現実的な最悪ケース。
+const REQUEST_TIMEOUT_MS = 5000;
+
 export class Dictionary implements BaseDictionary {
   #server: Server | undefined;
+  // ソケットの往復を直列化する。この接続は多重化を一切しておらず、`readCallback` の
+  // 置き場所が 1 つしかないため、2 つのリクエストが同時に処理中になると互いを上書きし、
+  // レスポンスが誤ったリクエストに紐付いてしまう（補完の問い合わせが変換の候補を受け取る、
+  // など）。すべての往復をこの promise に繋ぐことで、同時に送信中の往復を常に 1 つだけに
+  // 保つ。
+  #queue: Promise<unknown> = Promise.resolve();
   responseEncoding: Encoding;
   requestEncoding: Encoding;
   connectOptions: Deno.ConnectOptions;
@@ -54,6 +66,35 @@ export class Dictionary implements BaseDictionary {
       hostname: opts.hostname,
       port: opts.port,
     };
+  }
+
+  /** 先にキューへ入れた処理がすべて完了してから `task` を実行する。 */
+  #enqueue<T>(task: () => Promise<T>): Promise<T> {
+    const run = this.#queue.then(task, task);
+    // task が成功しても失敗しても鎖を継続し、ここで結果を握り潰すことで、処理されなかった
+    // 失敗がキューの末尾から漏れないようにする。
+    this.#queue = run.then(() => {}, () => {});
+    return run;
+  }
+
+  /**
+   * 1 つのコマンドを送り、その（1 行の）レスポンスで解決する。共有の `readCallback` が
+   * 競合しないよう、必ず #enqueue の内側からのみ呼ぶこと。接続の失敗やタイムアウト時は
+   * "" で解決する。
+   */
+  async #request(command: string): Promise<string> {
+    await this.connect();
+    if (!this.#server) return "";
+
+    const { promise, resolve } = Promise.withResolvers<string>();
+    const timer = setTimeout(() => resolve(""), REQUEST_TIMEOUT_MS);
+    this.#server.readCallback = (response: string) => {
+      clearTimeout(timer);
+      resolve(response);
+    };
+
+    await this.write(command);
+    return await promise;
   }
 
   async connect(close = false) {
@@ -84,20 +125,11 @@ export class Dictionary implements BaseDictionary {
     };
   }
 
-  async getHenkanResult(_type: HenkanType, word: string): Promise<string[]> {
-    await this.connect();
-
-    if (this.#server == null) return [];
-    const { promise, resolve } = Promise.withResolvers<string>();
-    this.#server.readCallback = resolve;
-
-    await this.write(`1${word} `);
-    const response = await promise;
-    const result = response.at(0) === "1"
-      ? response.split("/").slice(1, -1)
-      : [];
-
-    return result;
+  getHenkanResult(_type: HenkanType, word: string): Promise<string[]> {
+    return this.#enqueue(async () => {
+      const response = await this.#request(`1${word} `);
+      return response.at(0) === "1" ? response.split("/").slice(1, -1) : [];
+    });
   }
 
   async getCompletionResult(
@@ -128,23 +160,12 @@ export class Dictionary implements BaseDictionary {
     return candidates;
   }
 
-  private async getMidashis(prefix: string): Promise<string[]> {
+  private getMidashis(prefix: string): Promise<string[]> {
     // Get midashis from prefix
-    await this.connect();
-
-    if (!this.#server) return [];
-
-    if (this.#server == null) return [];
-    const { promise, resolve } = Promise.withResolvers<string>();
-    this.#server.readCallback = resolve;
-
-    await this.write(`4${prefix} `);
-    const response = await promise;
-    const result = response.at(0) === "1"
-      ? response.split(/\/|\s/).slice(1, -1)
-      : [];
-
-    return result;
+    return this.#enqueue(async () => {
+      const response = await this.#request(`4${prefix} `);
+      return response.at(0) === "1" ? response.split(/\/|\s/).slice(1, -1) : [];
+    });
   }
 
   async close() {

--- a/denops/skkeleton/sources/skk_server.ts
+++ b/denops/skkeleton/sources/skk_server.ts
@@ -26,6 +26,7 @@ export class Source implements BaseSource {
       port: config.skkServerPort,
       requestEnc: config.skkServerReqEnc,
       responseEnc: config.skkServerResEnc,
+      timeout: config.skkServerTimeout,
     });
 
     try {
@@ -41,20 +42,20 @@ export class Source implements BaseSource {
   }
 }
 
-// 1 回のリクエスト/レスポンスの往復にこの時間だけ猶予を与え、超えたら諦めて空で解決
-// する。応答が 1 つ失われても、下の直列化したキューがデッドロックしないようにするため。
-// skkserv の応答は通常ほぼ即座に返るが、ネットワーク上の skkserv が遅い辞書引きへ
-// フォールバックする場合が現実的な最悪ケース。
-const REQUEST_TIMEOUT_MS = 5000;
-
 export class Dictionary implements BaseDictionary {
   #server: Server | undefined;
-  // ソケットの往復を直列化する。この接続は多重化を一切しておらず、`readCallback` の
-  // 置き場所が 1 つしかないため、2 つのリクエストが同時に処理中になると互いを上書きし、
-  // レスポンスが誤ったリクエストに紐付いてしまう（補完の問い合わせが変換の候補を受け取る、
-  // など）。すべての往復をこの promise に繋ぐことで、同時に送信中の往復を常に 1 つだけに
-  // 保つ。
+  // Serializes socket round-trips. This connection is not multiplexed and has
+  // only one slot for `readCallback`, so two in-flight requests overwrite each
+  // other and a response gets tied to the wrong request (e.g. a completion
+  // query receiving conversion candidates). Chaining every round-trip onto this
+  // Promise keeps at most one round-trip in flight at a time.
   #queue: Promise<unknown> = Promise.resolve();
+  // Grace period for a single request/response round-trip. On timeout we give
+  // up and drop the connection so a single lost response can't deadlock the
+  // serialized queue above. skkserv normally replies almost instantly, but a
+  // networked skkserv falling back to a slow dictionary lookup is the realistic
+  // worst case, so this is configurable via `skkServerTimeout`.
+  #timeout: number;
   responseEncoding: Encoding;
   requestEncoding: Encoding;
   connectOptions: Deno.ConnectOptions;
@@ -62,32 +63,41 @@ export class Dictionary implements BaseDictionary {
   constructor(opts: SkkServerOptions) {
     this.requestEncoding = opts.requestEnc;
     this.responseEncoding = opts.responseEnc;
+    this.#timeout = opts.timeout;
     this.connectOptions = {
       hostname: opts.hostname,
       port: opts.port,
     };
   }
 
-  /** 先にキューへ入れた処理がすべて完了してから `task` を実行する。 */
+  /** Runs `task` only after everything already queued has settled. */
   #enqueue<T>(task: () => Promise<T>): Promise<T> {
     const run = this.#queue.then(task, task);
-    // task が成功しても失敗しても鎖を継続し、ここで結果を握り潰すことで、処理されなかった
-    // 失敗がキューの末尾から漏れないようにする。
+    // Continue the chain whether task fulfills or rejects, and swallow the
+    // result here so an unhandled rejection can't leak from the tail of the
+    // queue.
     this.#queue = run.then(() => {}, () => {});
     return run;
   }
 
   /**
-   * 1 つのコマンドを送り、その（1 行の）レスポンスで解決する。共有の `readCallback` が
-   * 競合しないよう、必ず #enqueue の内側からのみ呼ぶこと。接続の失敗やタイムアウト時は
-   * "" で解決する。
+   * Sends one command and resolves with its (single-line) response. Must be
+   * called only from within #enqueue so the shared `readCallback` never races.
+   * Resolves with "" on connection failure or timeout.
    */
   async #request(command: string): Promise<string> {
     await this.connect();
     if (!this.#server) return "";
 
     const { promise, resolve } = Promise.withResolvers<string>();
-    const timer = setTimeout(() => resolve(""), REQUEST_TIMEOUT_MS);
+    const timer = setTimeout(() => {
+      // The server may still send this response later; on a shared socket it
+      // would be misattributed to the next request and reintroduce the desync
+      // this queue prevents. Drop the connection so the in-flight response is
+      // discarded, and connect() re-establishes it on the next round-trip.
+      this.#discard();
+      resolve("");
+    }, this.#timeout);
     this.#server.readCallback = (response: string) => {
       clearTimeout(timer);
       resolve(response);
@@ -95,6 +105,15 @@ export class Dictionary implements BaseDictionary {
 
     await this.write(command);
     return await promise;
+  }
+
+  // Tears the connection down synchronously so that, by the time the next
+  // request calls connect(), `#server` is already gone and a fresh socket is
+  // opened. Any response still in flight on the old socket is dropped instead
+  // of leaking into the next request's `readCallback`.
+  #discard() {
+    this.#server?.conn.close();
+    this.#server = undefined;
   }
 
   async connect(close = false) {
@@ -114,7 +133,12 @@ export class Dictionary implements BaseDictionary {
             this.#server?.readCallback(response);
           },
         }),
-      ).finally(() => {
+      ).catch(() => {
+        // Closing the socket (e.g. from #discard() on timeout) interrupts the
+        // pending read and rejects this pipe with "operation canceled". That is
+        // expected teardown, so swallow it instead of leaking an unhandled
+        // rejection.
+      }).finally(() => {
         this.#server = undefined;
       });
     const writer = conn.writable.getWriter();
@@ -170,8 +194,7 @@ export class Dictionary implements BaseDictionary {
 
   async close() {
     await this.write("0");
-    this.#server?.conn.close();
-    this.#server = undefined;
+    this.#discard();
   }
 
   private async write(str: string) {

--- a/denops/skkeleton/types.ts
+++ b/denops/skkeleton/types.ts
@@ -26,6 +26,7 @@ export type Encoding = keyof typeof Encode;
 export type SkkServerOptions = {
   requestEnc: Encoding;
   responseEnc: Encoding;
+  timeout: number;
 } & Deno.ConnectOptions;
 
 export type ConfigOptions = {
@@ -53,6 +54,7 @@ export type ConfigOptions = {
   skkServerPort: number;
   skkServerReqEnc: Encoding;
   skkServerResEnc: Encoding;
+  skkServerTimeout: number;
   sources: string[];
   useGoogleJapaneseInput?: never;
   useSkkServer?: never;

--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -381,6 +381,12 @@ skkServerResEnc                             *skkeleton-config-skkServerResEnc*
         （デフォルト "euc-jp"）
         辞書サーバーから受け取る文字列のエンコード形式を指定します。
 
+skkServerTimeout                           *skkeleton-config-skkServerTimeout*
+        (デフォルト 5000)
+        辞書サーバーとの 1 回の送受信を待つ制限時間をミリ秒で指定します。この時
+        間を超えると応答を諦めてコネクションを切断します。ネットワーク越しの遅
+        い辞書サーバーを使う場合など、既定値では短いときに大きくします。
+
 sources                                             *skkeleton-config-sources*
         (デフォルト ["skk_dictionary"])
         使用する SKK 入力 source とその優先順位を指定します。ユーザー辞書はこ


### PR DESCRIPTION
## 問題

現在の実装では skkserv への通信時にコールバックを一つしか保持しません。そのため、リクエスト処理中に次のリクエストが来ると誤った宛先へレスポンスを送ってしまいます。

### 具体例

1. 変換のために `1へんかん ` をサーバーに送り、応答を待ちます。
2. 直後、補完のために `4へ ` を送ります。この時コールバックが上書きされます。
3. 先に `1/変換/返還/……/` のような応答が返ります。これが補完用のコールバックに返されます。

この例では被害が少ないですが、以下のように致命的な影響があります。

- **不正な見出しの表示**: 変換の候補には空白を含むもの（`(concat "&quest\073")` のような）があり、これを補完のコールバックが受け取ると空白の位置で切れて `(concat` のような妙な見出しがメニューに出ます。
- **ずれが固定化する**: 受け取り側の実装にも依りますが、この取り違いが起こると以後ずっとずれた相手にレスポンスを返し続けることになります。

実際にこの状況に遭遇したのは [Xantibody/blink-cmp-skkeleton](https://github.com/Xantibody/blink-cmp-skkeleton) で補完ロジックを非同期に書き直している時でした。その非同期化 PR（Xantibody/blink-cmp-skkeleton#20）と現行の skkeleton を使うと以下のような入力時に問題が再現します。

- skkserv へのリクエストが対話的な変換と同時に走る時。
  - 特に yaskkserv2 のような、Google 日本語入力へのフォールバックが有効な場合に起き易いです。
- 高速なタイピングで補完のリクエスト同士が重なる時。

## 修正

全ての往復を一列に並べ、必ず前のリクエストを処理してから次の処理に移ります（FIFO）。これで同時に送信中の往復は常に一つだけになり、コールバックが競合しません。

- `#enqueue()`: 各処理を一本の Promise に繋ぎます。成功・失敗のどちらでも次に移るようにしています。
- `#request()`: コマンドの送信と応答の受信を一組に纏めます。必ず `#enqueue()` の内側から呼び、コールバックを競合させません。
- 各往復には 5 秒のタイムアウト（`REQUEST_TIMEOUT_MS`）を設けました。応答が失われても次に進むようにしています。
