### PR TITLE
補完エンジン連携を登録制にする

### DIFF
--- a/autoload/skkeleton.vim
+++ b/autoload/skkeleton.vim
@@ -173,26 +173,8 @@ let s:completion_backends = {}
 let s:completion_backend = 'native'
 let s:warned_backends = {}
 
-let s:no_completion = #{ pum_visible: v:false, selected: -1 }
-
 function! s:native_complete_info() abort
   return complete_info(['pum_visible', 'selected'])
-endfunction
-
-function! s:nvim_cmp_complete_info() abort
-  if !has('nvim')
-        \ || !luaeval('select(2, pcall(function() return package.loaded["cmp"].visible() end)) == v:true')
-    return s:no_completion
-  endif
-  let selected = luaeval('require("cmp").get_active_entry() ~= nil')
-  return #{ pum_visible: v:true, selected: selected ? 1 : -1 }
-endfunction
-
-function! s:pum_complete_info() abort
-  if !exists('*pum#visible') || !pum#visible()
-    return s:no_completion
-  endif
-  return pum#complete_info(['pum_visible', 'selected'])
 endfunction
 
 function! skkeleton#register_completion_backend(name, backend) abort
@@ -208,17 +190,11 @@ function! skkeleton#register_completion_backend(name, backend) abort
   let s:completion_backends[a:name] = a:backend
 endfunction
 
+" Note: the built-in completion is the only one skkeleton knows by itself
+"       every other engine registers its own backend
 call skkeleton#register_completion_backend('native', #{
 \   complete_info: function('s:native_complete_info'),
 \   confirm_key: "\<C-y>",
-\ })
-call skkeleton#register_completion_backend('nvim-cmp', #{
-\   complete_info: function('s:nvim_cmp_complete_info'),
-\   confirm_key: "<Cmd>lua require('cmp').confirm({select = true})",
-\ })
-call skkeleton#register_completion_backend('pum.vim', #{
-\   complete_info: function('s:pum_complete_info'),
-\   confirm_key: '<Cmd>call pum#map#confirm()',
 \ })
 
 " return [backend_name, complete_info, confirm_key]

--- a/autoload/skkeleton.vim
+++ b/autoload/skkeleton.vim
@@ -144,6 +144,14 @@ function! s:notify_later(funcname, args) abort
 endfunction
 
 function! skkeleton#config(config) abort
+  " Note: keep a copy here because the Vim side looks the selected backend up
+  "       on every key press
+  if has_key(a:config, 'completionBackend')
+    if type(a:config.completionBackend) != v:t_string
+      throw '[skkeleton] completionBackend must be a string'
+    endif
+    let s:completion_backend = a:config.completionBackend
+  endif
   call skkeleton#request_async('config', [a:config])
 endfunction
 
@@ -161,20 +169,88 @@ function! skkeleton#register_kanatable_file(table_name, path, encoding='', creat
   call skkeleton#request_async('registerKanaTableFile', [a:table_name, a:path, a:encoding, a:create])
 endfunction
 
-" return [complete_type, complete_info]
-function! s:complete_info() abort
-  if exists('*pum#visible') && pum#visible()
-    return ['pum.vim', pum#complete_info(['pum_visible', 'selected'])]
-  elseif has('nvim') && luaeval('select(2, pcall(function() return package.loaded["cmp"].visible() end)) == true')
-    let selected = luaeval('require("cmp").get_active_entry() ~= nil')
-    return ['cmp', {'pum_visible': v:true, 'selected': selected ? 1 : -1}]
-  else
-    return ['native', complete_info(['pum_visible', 'selected'])]
-  endif
+let s:completion_backends = {}
+let s:completion_backend = 'native'
+let s:warned_backends = {}
+
+let s:no_completion = #{ pum_visible: v:false, selected: -1 }
+
+function! s:native_complete_info() abort
+  return complete_info(['pum_visible', 'selected'])
 endfunction
 
+function! s:nvim_cmp_complete_info() abort
+  if !has('nvim')
+        \ || !luaeval('select(2, pcall(function() return package.loaded["cmp"].visible() end)) == v:true')
+    return s:no_completion
+  endif
+  let selected = luaeval('require("cmp").get_active_entry() ~= nil')
+  return #{ pum_visible: v:true, selected: selected ? 1 : -1 }
+endfunction
+
+function! s:pum_complete_info() abort
+  if !exists('*pum#visible') || !pum#visible()
+    return s:no_completion
+  endif
+  return pum#complete_info(['pum_visible', 'selected'])
+endfunction
+
+function! skkeleton#register_completion_backend(name, backend) abort
+  if type(a:name) != v:t_string
+    throw '[skkeleton] completion backend name must be a string'
+  endif
+  if type(a:backend) != v:t_dict
+        \ || type(get(a:backend, 'complete_info')) != v:t_func
+        \ || type(get(a:backend, 'confirm_key')) != v:t_string
+    throw '[skkeleton] completion backend must be ' ..
+          \ '{complete_info: funcref, confirm_key: string}'
+  endif
+  let s:completion_backends[a:name] = a:backend
+endfunction
+
+call skkeleton#register_completion_backend('native', #{
+\   complete_info: function('s:native_complete_info'),
+\   confirm_key: "\<C-y>",
+\ })
+call skkeleton#register_completion_backend('nvim-cmp', #{
+\   complete_info: function('s:nvim_cmp_complete_info'),
+\   confirm_key: "<Cmd>lua require('cmp').confirm({select = true})",
+\ })
+call skkeleton#register_completion_backend('pum.vim', #{
+\   complete_info: function('s:pum_complete_info'),
+\   confirm_key: '<Cmd>call pum#map#confirm()',
+\ })
+
+" return [backend_name, complete_info, confirm_key]
+function! s:complete_info() abort
+  let name = s:completion_backend
+  if !has_key(s:completion_backends, name)
+    " Note: a backend registered from `skkeleton-enable-pre` is still missing on
+    "       the first key press, and no completion menu can be open yet either
+    let name = 'native'
+  endif
+  let backend = s:completion_backends[name]
+  return [name, backend.complete_info(), backend.confirm_key]
+endfunction
+
+function! s:check_completion_backend() abort
+  let name = s:completion_backend
+  if has_key(s:completion_backends, name) || has_key(s:warned_backends, name)
+    return
+  endif
+  let s:warned_backends[name] = v:true
+  echohl WarningMsg
+  echomsg printf('[skkeleton] unknown completionBackend: %s (fallback to "native")', name)
+  echohl None
+endfunction
+
+augroup skkeleton-completion-backend
+  autocmd!
+  autocmd User skkeleton-enable-post call s:check_completion_backend()
+augroup END
+
 function! skkeleton#vim_status() abort
-  let [complete_type, complete_info] = s:complete_info()
+  let [complete_type, complete_info, complete_confirm_key] = s:complete_info()
   let m = mode()
   if m ==# 'i'
     let prev_input = getline('.')[:col('.')-2]
@@ -189,6 +265,7 @@ function! skkeleton#vim_status() abort
   \ 'prevInput': prev_input,
   \ 'completeInfo': complete_info,
   \ 'completeType': complete_type,
+  \ 'completeConfirmKey': complete_confirm_key,
   \ 'mode': m,
   \ }
 endfunction

--- a/denops/skkeleton/completion_backend_test.ts
+++ b/denops/skkeleton/completion_backend_test.ts
@@ -131,7 +131,7 @@ test({
     await d.call("skkeleton#config", { completionBackend: "late-engine" });
     await d.cmd("messages clear");
 
-    // 最初のキー処理では未登録なのでnativeに落ちる
+    // falls back to native because it is not registered on the first key
     assertEquals((await vimStatus(d)).completeType, "native");
 
     await d.cmd("doautocmd <nomodeline> User skkeleton-enable-pre");

--- a/denops/skkeleton/completion_backend_test.ts
+++ b/denops/skkeleton/completion_backend_test.ts
@@ -1,0 +1,161 @@
+import { config } from "./config.ts";
+import { test } from "./testutil.ts";
+
+import type { Denops } from "@denops/std";
+import { assertEquals } from "@std/assert/equals";
+import { assertRejects } from "@std/assert/rejects";
+import { assertStringIncludes } from "@std/assert/string-includes";
+
+const defaultConfig = { ...config };
+
+type VimStatus = {
+  completeInfo: { selected: number };
+  completeType: string;
+  completeConfirmKey: string;
+};
+
+async function vimStatus(d: Denops): Promise<VimStatus> {
+  return await d.call("skkeleton#vim_status") as VimStatus;
+}
+
+// Note: `selected` while no completion is showing
+const notSelected = -1;
+
+test({
+  mode: "all",
+  name: "default completion backend is native",
+  async fn(d: Denops) {
+    Object.assign(config, defaultConfig);
+    const status = await vimStatus(d);
+    assertEquals(status.completeType, "native");
+    assertEquals(status.completeConfirmKey, "\x19"); // <C-y>
+    assertEquals(status.completeInfo.selected, notSelected);
+  },
+});
+
+test({
+  mode: "all",
+  name: "built-in completion backends are selectable",
+  async fn(d: Denops) {
+    Object.assign(config, defaultConfig);
+    await d.call("skkeleton#config", { completionBackend: "pum.vim" });
+    const status = await vimStatus(d);
+    assertEquals(status.completeType, "pum.vim");
+    assertEquals(status.completeConfirmKey, "<Cmd>call pum#map#confirm()");
+    // pum.vim is not loaded, so it reports that nothing is showing
+    assertEquals(status.completeInfo.selected, notSelected);
+  },
+});
+
+test({
+  mode: "all",
+  name: "registered completion backend is selectable",
+  async fn(d: Denops) {
+    Object.assign(config, defaultConfig);
+    await d.cmd(
+      "function! g:SkkeletonTestCompleteInfo() abort\n" +
+        "  return #{ pum_visible: v:true, selected: 42 }\n" +
+        "endfunction",
+    );
+    await d.cmd(
+      "call skkeleton#register_completion_backend('test-engine', #{" +
+        "  complete_info: function('g:SkkeletonTestCompleteInfo')," +
+        "  confirm_key: '<Cmd>call g:SkkeletonTestConfirm()'," +
+        "})",
+    );
+    await d.call("skkeleton#config", { completionBackend: "test-engine" });
+    const status = await vimStatus(d);
+    assertEquals(status.completeType, "test-engine");
+    assertEquals(
+      status.completeConfirmKey,
+      "<Cmd>call g:SkkeletonTestConfirm()",
+    );
+    assertEquals(status.completeInfo.selected, 42);
+  },
+});
+
+test({
+  mode: "all",
+  name: "unknown completion backend falls back to native",
+  async fn(d: Denops) {
+    Object.assign(config, defaultConfig);
+    await d.call("skkeleton#config", { completionBackend: "no-such-engine" });
+    const status = await vimStatus(d);
+    assertEquals(status.completeType, "native");
+    assertEquals(status.completeConfirmKey, "\x19"); // <C-y>
+  },
+});
+
+test({
+  mode: "all",
+  name: "unknown completion backend is reported at skkeleton-enable-post",
+  async fn(d: Denops) {
+    Object.assign(config, defaultConfig);
+    await d.call("skkeleton#config", { completionBackend: "no-such-engine" });
+    await d.cmd("messages clear");
+    // a completion source registers from skkeleton-enable-pre, which runs after
+    // the first skkeleton#vim_status(), so nothing is reported from there
+    await vimStatus(d);
+    await vimStatus(d);
+    assertEquals(
+      (await d.call("execute", "messages") as string).includes(
+        "unknown completionBackend",
+      ),
+      false,
+    );
+    await d.cmd("doautocmd <nomodeline> User skkeleton-enable-post");
+    assertStringIncludes(
+      await d.call("execute", "messages") as string,
+      "unknown completionBackend: no-such-engine",
+    );
+  },
+});
+
+test({
+  mode: "all",
+  name: "a backend registered from skkeleton-enable-pre is not reported",
+  async fn(d: Denops) {
+    Object.assign(config, defaultConfig);
+    await d.cmd(
+      "function! g:SkkeletonTestLateCompleteInfo() abort\n" +
+        "  return #{ pum_visible: v:false, selected: -1 }\n" +
+        "endfunction",
+    );
+    await d.cmd(
+      "autocmd User skkeleton-enable-pre ++once" +
+        "  call skkeleton#register_completion_backend('late-engine', #{" +
+        "    complete_info: function('g:SkkeletonTestLateCompleteInfo')," +
+        "    confirm_key: '<Cmd>call g:SkkeletonTestConfirm()'," +
+        "  })",
+    );
+    await d.call("skkeleton#config", { completionBackend: "late-engine" });
+    await d.cmd("messages clear");
+
+    // 最初のキー処理では未登録なのでnativeに落ちる
+    assertEquals((await vimStatus(d)).completeType, "native");
+
+    await d.cmd("doautocmd <nomodeline> User skkeleton-enable-pre");
+    await d.cmd("doautocmd <nomodeline> User skkeleton-enable-post");
+    assertEquals(
+      (await d.call("execute", "messages") as string).includes(
+        "unknown completionBackend",
+      ),
+      false,
+    );
+    assertEquals((await vimStatus(d)).completeType, "late-engine");
+  },
+});
+
+test({
+  mode: "all",
+  name: "invalid completion backend definition is rejected",
+  async fn(d: Denops) {
+    await assertRejects(async () => {
+      await d.cmd(
+        "call skkeleton#register_completion_backend('broken', #{" +
+          "  confirm_key: '<Cmd>call g:SkkeletonTestConfirm()'," +
+          "})",
+      );
+    });
+  },
+});

--- a/denops/skkeleton/completion_backend_test.ts
+++ b/denops/skkeleton/completion_backend_test.ts
@@ -35,20 +35,6 @@ test({
 
 test({
   mode: "all",
-  name: "built-in completion backends are selectable",
-  async fn(d: Denops) {
-    Object.assign(config, defaultConfig);
-    await d.call("skkeleton#config", { completionBackend: "pum.vim" });
-    const status = await vimStatus(d);
-    assertEquals(status.completeType, "pum.vim");
-    assertEquals(status.completeConfirmKey, "<Cmd>call pum#map#confirm()");
-    // pum.vim is not loaded, so it reports that nothing is showing
-    assertEquals(status.completeInfo.selected, notSelected);
-  },
-});
-
-test({
-  mode: "all",
   name: "registered completion backend is selectable",
   async fn(d: Denops) {
     Object.assign(config, defaultConfig);

--- a/denops/skkeleton/config.ts
+++ b/denops/skkeleton/config.ts
@@ -10,6 +10,7 @@ export const config: Omit<ConfigOptions, "globalDictionaries"> & {
   globalDictionaries: [string, string][];
 } = {
   acceptIllegalResult: false,
+  completionBackend: "native",
   completionRankFile: "",
   databasePath: "",
   debug: false,
@@ -51,6 +52,7 @@ function ensureEncoding(x: unknown): Encoding {
 
 const validators: Validators = {
   acceptIllegalResult: (x) => ensure(x, is.Boolean),
+  completionBackend: (x) => ensure(x, is.String),
   completionRankFile: (x) => ensure(x, is.String),
   databasePath: (x) => ensure(x, is.String),
   debug: (x) => ensure(x, is.Boolean),

--- a/denops/skkeleton/main.ts
+++ b/denops/skkeleton/main.ts
@@ -30,6 +30,7 @@ type VimStatus = {
   prevInput: string;
   completeInfo: CompleteInfo;
   completeType: string;
+  completeConfirmKey: string;
   mode: string;
 };
 
@@ -158,21 +159,16 @@ async function disable(opts: unknown, vimStatus: unknown): Promise<string> {
   return context.preEdit.output(context.toString());
 }
 
+// Note: the confirm key comes from the Vim side as part of the completion
+//       backend definition (|skkeleton#register_completion_backend()|)
 function handleCompleteKey(
   completed: boolean,
-  completeType: string,
+  confirmKey: string,
   notation: string,
 ): string | null {
   if (notation === "<cr>") {
-    if (completed && config.eggLikeNewline) {
-      switch (completeType) {
-        case "native":
-          return notationToKey["<c-y>"];
-        case "pum.vim":
-          return "<Cmd>call pum#map#confirm()";
-        case "cmp":
-          return "<Cmd>lua require('cmp').confirm({select = true})";
-      }
+    if (completed && config.eggLikeNewline && confirmKey !== "") {
+      return confirmKey;
     }
   }
   return null;
@@ -186,7 +182,8 @@ async function handle(
   const keyList = opts.key.map((key) => {
     return keyToNotation[notationToKey[key]] ?? key;
   });
-  const { completeInfo, completeType, mode } = vimStatus as VimStatus;
+  const { completeInfo, completeType, completeConfirmKey, mode } =
+    vimStatus as VimStatus;
   const context = currentContext.get();
   context.vimMode = mode;
   if (completeInfo.pum_visible) {
@@ -202,7 +199,7 @@ async function handle(
     }
     const handled = handleCompleteKey(
       completeInfo.selected >= 0,
-      completeType,
+      completeConfirmKey ?? "",
       notation,
     );
     if (is.String(handled)) {

--- a/denops/skkeleton/types.ts
+++ b/denops/skkeleton/types.ts
@@ -31,6 +31,7 @@ export type SkkServerOptions = {
 
 export type ConfigOptions = {
   acceptIllegalResult: boolean;
+  completionBackend: string;
   completionRankFile: string;
   databasePath: string;
   debug: boolean;

--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -237,6 +237,20 @@ acceptIllegalResult                     *skkeleton-config-acceptIllegalResult*
         このオプションを有効にすると、Microsoft IME等と同様に
         入力に失敗したローマ字がバッファに残るようになります。
 
+completionBackend                         *skkeleton-config-completionBackend*
+        (デフォルト "native")
+        補完エンジンとの連携に使うバックエンドの名前です。
+        |skkeleton-config-eggLikeNewline| による確定の際に、補完メニューが
+        表示されているかの判定と候補の確定をこのバックエンドに委譲します。
+        以下のバックエンドを内蔵しています:
+                "native"        Vim/Neovimの組み込み補完(|ins-completion|)
+                "nvim-cmp"      https://github.com/hrsh7th/nvim-cmp
+                "pum.vim"       https://github.com/Shougo/pum.vim
+        これら以外の補完エンジンを使う場合は
+        |skkeleton#register_completion_backend()| で登録した名前を指定します。
+        Note: 使用中の補完エンジンの自動判定は行いません。組み込み補完以外を
+        使う場合は必ず設定してください。(|skkeleton-compatibility|)
+
 completionRankFile                       *skkeleton-config-completionRankFile*
         (デフォルト "")
         パスを指定すると補完候補の順番を記録するようになります。
@@ -418,6 +432,45 @@ userDictionary                               *skkeleton-config-userDictionary*
         JavaScriptの制約によりエンコーディングはUTF-8限定になります。
 
 ------------------------------------------------------------------------------
+                                    *skkeleton#register_completion_backend()*
+skkeleton#register_completion_backend({name}, {backend})
+        補完エンジンとの連携方法を登録します。登録した{name}は
+        |skkeleton-config-completionBackend| に指定できるようになります。
+        同じ{name}が既に登録されている場合は上書きされます。
+        {backend}には以下のキーを持つ辞書を指定します:
+                complete_info
+                        補完の表示状態を返す |Funcref| です。 `pum_visible` と
+                        `selected` をキーに持つ辞書を返してください。
+                        `selected` は候補が選択されていない場合に負数を返しま
+                        す。
+                confirm_key
+                        選択中の候補を確定するキーの文字列です。 `<Cmd>` で始
+                        まる場合はコマンドとして実行されます(終端の `<CR>` は
+                        不要です)。
+        ユーザーが直接呼ぶこともできますが、補完ソースを提供するプラグイン側で
+        呼ぶことを想定しています。 |skkeleton-enable-pre| までに呼ばれていれば
+        間に合います。
+>lua
+    -- 例: blink.cmp
+    vim.fn["skkeleton#register_completion_backend"]("blink.cmp", {
+      complete_info = function()
+        local blink = require("blink.cmp")
+        if not blink.is_menu_visible() then
+          return { pum_visible = false, selected = -1 }
+        end
+        return {
+          pum_visible = true,
+          selected = blink.get_selected_item() ~= nil and 1 or -1,
+        }
+      end,
+      confirm_key = "<Cmd>lua require('blink.cmp').select_and_accept()",
+    })
+<
+>vim
+    " 登録した名前を選択する (こちらはユーザーが行う)
+    call skkeleton#config(#{ completionBackend: 'blink.cmp' })
+<
+------------------------------------------------------------------------------
                                               *skkeleton#register_kanatable()*
 skkeleton#register_kanatable({tableName}, {table} [, {create}])
         仮名入力のテーブルを登録できます。
@@ -547,6 +600,16 @@ COMPLETION                                              *skkeleton-completion*
         \ })
     call skkeleton#config({'completionRankFile': '~/.skkeleton/rank.json'})
 <
+                                                *skkeleton-completion-backend*
+    補完エンジンが表示している候補を |skkeleton-config-eggLikeNewline| による
+    改行キーで確定するには、使用している補完エンジンを
+    |skkeleton-config-completionBackend| で指定する必要があります。
+>vim
+    call skkeleton#config(#{ completionBackend: 'pum.vim' })
+<
+    内蔵していない補完エンジンとの連携については
+    |skkeleton#register_completion_backend()| を参照してください。
+
 ==============================================================================
 FAQ                                                            *skkeleton-faq*
 
@@ -675,6 +738,13 @@ skkeleton側では |g:skkeleton#mapped_keys| に応じて
 
 ==============================================================================
 COMPATIBILITY                                        *skkeleton-compatibility*
+
+2026-08-08~
+- 補完エンジンの自動判定を廃止
+  - |skkeleton-config-completionBackend| による明示的な指定が必要になりました
+  - 組み込み補完("native")以外を使っている場合は設定を追加してください
+  - 内蔵していない補完エンジンは
+    |skkeleton#register_completion_backend()| で登録できます
 
 2024-12-17~
 - denops.vimのv8で追加された仕様に追従

--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -242,12 +242,10 @@ completionBackend                         *skkeleton-config-completionBackend*
         補完エンジンとの連携に使うバックエンドの名前です。
         |skkeleton-config-eggLikeNewline| による確定の際に、補完メニューが
         表示されているかの判定と候補の確定をこのバックエンドに委譲します。
-        以下のバックエンドを内蔵しています:
-                "native"        Vim/Neovimの組み込み補完(|ins-completion|)
-                "nvim-cmp"      https://github.com/hrsh7th/nvim-cmp
-                "pum.vim"       https://github.com/Shougo/pum.vim
-        これら以外の補完エンジンを使う場合は
-        |skkeleton#register_completion_backend()| で登録した名前を指定します。
+        内蔵しているのはVim/Neovimの組み込み補完(|ins-completion|)を扱う
+        "native" だけです。他の補完エンジンを使う場合は
+        |skkeleton#register_completion_backend()| で登録された名前を
+        指定します。
         Note: 使用中の補完エンジンの自動判定は行いません。組み込み補完以外を
         使う場合は必ず設定してください。(|skkeleton-compatibility|)
 
@@ -605,10 +603,10 @@ COMPLETION                                              *skkeleton-completion*
     改行キーで確定するには、使用している補完エンジンを
     |skkeleton-config-completionBackend| で指定する必要があります。
 >vim
-    call skkeleton#config(#{ completionBackend: 'pum.vim' })
+    call skkeleton#config(#{ completionBackend: 'blink.cmp' })
 <
-    内蔵していない補完エンジンとの連携については
-    |skkeleton#register_completion_backend()| を参照してください。
+    組み込み補完("native")以外のバックエンドは、補完エンジン側から
+    |skkeleton#register_completion_backend()| で登録されている必要があります。
 
 ==============================================================================
 FAQ                                                            *skkeleton-faq*
@@ -743,8 +741,9 @@ COMPATIBILITY                                        *skkeleton-compatibility*
 - 補完エンジンの自動判定を廃止
   - |skkeleton-config-completionBackend| による明示的な指定が必要になりました
   - 組み込み補完("native")以外を使っている場合は設定を追加してください
-  - 内蔵していない補完エンジンは
-    |skkeleton#register_completion_backend()| で登録できます
+  - "native" 以外のバックエンドは補完エンジン側が
+    |skkeleton#register_completion_backend()| で登録します。まだ対応していない
+    補完エンジンについてはユーザーが自分で登録することもできます
 
 2024-12-17~
 - denops.vimのv8で追加された仕様に追従

--- a/doc/skkeleton.jax
+++ b/doc/skkeleton.jax
@@ -737,7 +737,7 @@ skkeleton側では |g:skkeleton#mapped_keys| に応じて
 ==============================================================================
 COMPATIBILITY                                        *skkeleton-compatibility*
 
-2026-08-08~
+2026-09-10~
 - 補完エンジンの自動判定を廃止
   - |skkeleton-config-completionBackend| による明示的な指定が必要になりました
   - 組み込み補完("native")以外を使っている場合は設定を追加してください


### PR DESCRIPTION
#249 で相談していた件です。案 X（デフォルトは native、それ以外はユーザーが明示的に指定する）で実装しました。

## 変更内容

補完エンジンの自動判定を廃止し、名前で登録・選択する形にしました。

```vim
" 補完ソースを提供するプラグイン側で登録します
call skkeleton#register_completion_backend('blink.cmp', #{
  \   complete_info: {-> ...},
  \   confirm_key: "<Cmd>lua require('blink.cmp').select_and_accept()",
  \ })

" ユーザーはどれを使うか選びます
call skkeleton#config(#{ completionBackend: 'blink.cmp' })
```

- `complete_info()`: `pum_visible` と `selected` を持つ辞書を返します。
- `confirm_key`: 選択中の候補を確定するキーです。`<Cmd>` で始まる場合はコマンドとして実行されます。

内蔵しているのは組み込み補完 (`ins-completion`) を扱う `native` だけで、これがデフォルトです。当初は `nvim-cmp` / `pum.vim` も内蔵していましたが、レビューでの指摘を受けて削除しました。バックエンドの定義は追従すべきエンジンの側にあるべきで、そちらが適切だと思います。

併せて `skkeleton#vim_status()` が `confirm_key` を返すようにしたので、`handleCompleteKey()` からエンジン毎の分岐が無くなりました。これで新しい補完エンジンへの対応に本体の変更が要らなくなります。

## 破壊的変更

補完エンジンを自動判定しなくなります。組み込み補完以外を使っているユーザーは、バックエンドの登録と選択が必要になります。`COMPATIBILITY` に追記しました。

登録は補完エンジン側で行われるのが前提で、ユーザーは名前を選ぶだけです。

```vim
call skkeleton#config(#{ completionBackend: 'blink.cmp' })
```

エンジン側の状況は以下の通りです。

- pum.vim: Shougo さんが pum.vim 側で対応してくださるとのことです。
- blink.cmp: blink-cmp-skkeleton に Draft PR を出しています (下記)。
- nvim-cmp: [cmp-skkeleton](https://github.com/uga-rosa/cmp-skkeleton) に PR を出す予定です。

エンジン側が未対応の間は、ユーザーが `skkeleton#register_completion_backend()` を自分で呼んでも同じことができます。

#249 で話に出ていた通り v3.0.0 でリリースするのが適切かと思います。

## 関連

#251 との関係を確認するため、手元でこのブランチにマージして試してみましたが、正しく動作し、コードもコンフリクトしません（`doc/skkeleton.jax` の `*skkeleton-completion*` 節だけは両方の追記を並べる必要があります）。マージはどちらが先でも問題ありません。

blink.cmp については [blink-cmp-skkeleton](https://github.com/Xantibody/blink-cmp-skkeleton) 側に Draft PR を出しています（Xantibody/blink-cmp-skkeleton#21）。

## 確認

`completion_backend_test.ts` を追加しました。手元では blink.cmp / ddc-ui-native / ddc-ui-pum + pum.vim / #251 completefunc の 4 構成で、`eggLikeNewline` の `<CR>` による確定を確認しています。pum.vim の確認は削除した内蔵定義で行ったものですが、同じ内容をエンジン側で登録すれば同じように動きます。

