### PR TITLE
無効化された後に変換候補のポップアップが残るのを修正

### DIFF
--- a/autoload/skkeleton.vim
+++ b/autoload/skkeleton.vim
@@ -235,6 +235,9 @@ endfunction
 function! skkeleton#disable()
   if g:skkeleton#enabled
     doautocmd <nomodeline> User skkeleton-disable-pre
+    " the candidate popup is closed on `User skkeleton-handled`, which no
+    " longer fires once disabled
+    call skkeleton#popup#close()
     call skkeleton#internal#map#restore()
     call skkeleton#internal#option#restore()
     let g:skkeleton#mode = ''

--- a/autoload/skkeleton/popup.vim
+++ b/autoload/skkeleton/popup.vim
@@ -32,6 +32,11 @@ function! s:open_cmdline(candidates)
 endfunction
 
 function! s:open(candidates) abort
+  " Note: do nothing when skkeleton has been disabled before this opens, or it
+  "       would be left open (e.g. when insert mode is left with `<C-c>`)
+  if !g:skkeleton#enabled
+    return
+  endif
   autocmd skkeleton-internal User skkeleton-handled ++once call skkeleton#popup#close()
   if mode() == 'c'
     call s:open_cmdline(a:candidates)


### PR DESCRIPTION
## 問題

変換候補の一覧を表示している状態で挿入モードを `<C-c>` で抜けると、ポップアップが表示されたまま残ります。`showCandidatesCount` を小さくしていると踏みやすいです。

## 原因

候補一覧は `s:open()` が仕込む `User skkeleton-handled` の `++once` autocmd で閉じています。`<C-c>` は skkeleton にキーが渡らず `ModeChanged` の autocmd 経由で無効化されるため、以降 `skkeleton-handled` が発生せず、閉じる契機がありません。

## 修正

`skkeleton#disable()` で閉じるようにしました。ポップアップは `skkeleton-handled` 経由で「キーを処理した 1 イベント後」に開くため、無効化が先に走ると閉じた後から開かれてしまいます。開く側でも無効化されていたら何もしないようにしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
